### PR TITLE
Initialize Firebase config once for site and admin

### DIFF
--- a/duo-parfum-pro/README.md
+++ b/duo-parfum-pro/README.md
@@ -6,9 +6,10 @@
 - Pronto para Vercel.
 
 ## Passos
-1. Firebase Web App → copie o config para `app.js` e `admin.html`.
-2. Ajuste `ADMIN_EMAILS` e `WHATSAPP_PHONE`.
+1. Firebase Web App → copie o config para `firebase-init.js` (ou ajuste `window.firebaseConfig`).
+2. Ajuste `ADMIN_EMAILS` conforme os administradores da loja.
 3. Firestore: coleção `products`. Regras iniciais iguais ao pacote anterior.
-4. Deploy na Vercel (arraste esta pasta).
+4. Configure as variáveis `MP_ACCESS_TOKEN`, `MP_PAYER_EMAIL` (opcional) e `MP_NOTIFICATION_URL` (opcional) na Vercel para gerar pagamentos.
+5. Deploy na Vercel (arraste esta pasta).
 
 Gerado em 2025-08-10

--- a/duo-parfum-pro/admin.html
+++ b/duo-parfum-pro/admin.html
@@ -17,6 +17,7 @@
   <script defer src="https://www.gstatic.com/firebasejs/10.12.4/firebase-auth-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.4/firebase-firestore-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.4/firebase-storage-compat.js"></script>
+  <script defer src="./firebase-init.js"></script>
 </head>
 <body>
   <header class="topbar">
@@ -58,6 +59,19 @@
     const ADMIN_EMAILS = ["guilhermeserraglio03@gmail.com"];
 
     document.addEventListener("DOMContentLoaded", () => {
+      const firebaseConfig = window.firebaseConfig || {
+        apiKey: "AIzaSyDVkpsr4z6LolEOkNTGcc9TmKeiu4-mi1Y",
+        authDomain: "duoparfum-61ec2.firebaseapp.com",
+        projectId: "duoparfum-61ec2",
+        storageBucket: "duoparfum-61ec2.firebasestorage.app",
+        messagingSenderId: "889684986920",
+        appId: "1:889684986920:web:9d452daf2192124b19391d"
+      };
+
+      if (!firebase.apps?.length) {
+        firebase.initializeApp(firebaseConfig);
+      }
+
       const auth = firebase.auth();
       const db = firebase.firestore();
       const storage = firebase.storage();

--- a/duo-parfum-pro/app.js
+++ b/duo-parfum-pro/app.js
@@ -1,5 +1,5 @@
 /* ========= CONFIG FIREBASE ========= */
-const firebaseConfig = {
+const firebaseConfig = window.firebaseConfig || {
   apiKey: "AIzaSyDVkpsr4z6LolEOkNTGcc9TmKeiu4-mi1Y",
   authDomain: "duoparfum-61ec2.firebaseapp.com",
   projectId: "duoparfum-61ec2",
@@ -13,7 +13,7 @@ const ADMIN_EMAILS = ["guilhermeserraglio03@gmail.com"];
 let app, db, auth;
 
 document.addEventListener("DOMContentLoaded", async () => {
-  app = firebase.initializeApp(firebaseConfig);
+  app = firebase.apps?.length ? firebase.app() : firebase.initializeApp(firebaseConfig);
   auth = firebase.auth();
   db = firebase.firestore();
 

--- a/duo-parfum-pro/firebase-init.js
+++ b/duo-parfum-pro/firebase-init.js
@@ -1,0 +1,25 @@
+(function(){
+  const config = {
+    apiKey: "AIzaSyDVkpsr4z6LolEOkNTGcc9TmKeiu4-mi1Y",
+    authDomain: "duoparfum-61ec2.firebaseapp.com",
+    projectId: "duoparfum-61ec2",
+    storageBucket: "duoparfum-61ec2.firebasestorage.app",
+    messagingSenderId: "889684986920",
+    appId: "1:889684986920:web:9d452daf2192124b19391d"
+  };
+
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.firebaseConfig = config;
+
+  if (!window.firebase) {
+    console.error("Firebase SDK não carregado. Verifique a ordem dos scripts.");
+    return;
+  }
+
+  if (!firebase.apps || !firebase.apps.length) {
+    firebase.initializeApp(config);
+  }
+})();

--- a/duo-parfum-pro/index.html
+++ b/duo-parfum-pro/index.html
@@ -16,6 +16,7 @@
   <script defer src="https://www.gstatic.com/firebasejs/10.12.4/firebase-app-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.4/firebase-auth-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.4/firebase-firestore-compat.js"></script>
+  <script defer src="./firebase-init.js"></script>
 
   <!-- App -->
   <script defer src="./app.js"></script>


### PR DESCRIPTION
## Summary
- add a shared firebase-init script to bootstrap the SDK for both storefront and admin
- update the storefront app to reuse existing Firebase apps and document the new configuration flow
- ensure the admin panel loads the shared config before using auth, firestore and storage

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d30a67f0f48330967d20f745d58c96