### PR TITLE
Fix product creation timestamp and validation

### DIFF
--- a/duo-parfum-pro/admin.html
+++ b/duo-parfum-pro/admin.html
@@ -106,6 +106,12 @@
         e.preventDefault();
         const file = els.pImage.files[0];
         let url = "";
+        const priceValue = parseFloat(els.pPrice.value);
+
+        if (!Number.isFinite(priceValue)) {
+          alert("Informe um preço válido.");
+          return;
+        }
 
         try {
           if (file) {
@@ -114,17 +120,19 @@
             url = await ref.getDownloadURL();
           }
 
+          const timestamp = firebase.firestore.FieldValue.serverTimestamp();
+
           await db.collection("products").add({
             name: els.pName.value,
             brand: els.pBrand.value,
             ml: els.pMl.value,
-            price: parseFloat(els.pPrice.value),
+            price: priceValue,
             notes: els.pNotes.value,
             category: els.pCategory.value,
             image: url,
             stock: 0,
             featured: false,
-            createdAt: new Date()
+            createdAt: timestamp
           });
 
           els.form.reset();


### PR DESCRIPTION
## Summary
- use Firebase server timestamps when creating products so Firestore security rules accept the write
- validate the product price before sending the document to Firestore

## Testing
- not run (static project)


------
https://chatgpt.com/codex/tasks/task_e_68d31bf250f0833086bfbe00c483e5df