### PR TITLE
Add secured product management API and update admin UI

### DIFF
--- a/duo-parfum-pro/admin.html
+++ b/duo-parfum-pro/admin.html
@@ -90,6 +90,74 @@
         btnLogout: document.getElementById("btnLogout")
       };
 
+      async function callProductsApi(method, payload = {}) {
+        const user = auth.currentUser;
+        if (!user) {
+          const error = new Error("Usuário não autenticado");
+          error.displayed = true;
+          alert("Faça login novamente para continuar.");
+          throw error;
+        }
+
+        let token;
+        try {
+          token = await user.getIdToken();
+        } catch (err) {
+          console.error("Erro ao obter token de autenticação:", err);
+          const error = new Error("Falha ao obter token de autenticação");
+          error.displayed = true;
+          alert("Não foi possível confirmar sua autenticação. Faça login novamente.");
+          throw error;
+        }
+
+        const options = {
+          method,
+          headers: {
+            Authorization: `Bearer ${token}`
+          }
+        };
+
+        if (method !== "GET" && method !== "HEAD") {
+          options.headers["Content-Type"] = "application/json";
+          options.body = JSON.stringify(payload || {});
+        }
+
+        try {
+          const response = await fetch("/api/products", options);
+          const text = await response.text();
+          let data = null;
+
+          if (text) {
+            try {
+              data = JSON.parse(text);
+            } catch (err) {
+              console.warn("Resposta da API de produtos não está em JSON válido:", err);
+            }
+          }
+
+          if (!response.ok) {
+            let message = (data && data.error) || "Erro ao processar a solicitação.";
+            if (response.status === 401 || response.status === 403) {
+              message = "Acesso negado. Somente administradores autorizados podem realizar esta ação.";
+            }
+            alert(message);
+            const error = new Error(message);
+            error.status = response.status;
+            error.displayed = true;
+            error.details = data;
+            throw error;
+          }
+
+          return data;
+        } catch (err) {
+          if (!err?.displayed) {
+            alert("Não foi possível comunicar com o servidor. Tente novamente.");
+            err.displayed = true;
+          }
+          throw err;
+        }
+      }
+
       /* ==== Proteção de acesso ==== */
       auth.onAuthStateChanged(user => {
         if (!user || !ADMIN_EMAILS.includes(user.email)) {
@@ -120,9 +188,7 @@
             url = await ref.getDownloadURL();
           }
 
-          const timestamp = firebase.firestore.FieldValue.serverTimestamp();
-
-          await db.collection("products").add({
+          await callProductsApi("POST", {
             name: els.pName.value,
             brand: els.pBrand.value,
             ml: els.pMl.value,
@@ -130,16 +196,16 @@
             notes: els.pNotes.value,
             category: els.pCategory.value,
             image: url,
-            stock: 0,
-            featured: false,
-            createdAt: timestamp
+            featured: false
           });
 
           els.form.reset();
           loadProducts();
         } catch (err) {
           console.error("Erro ao salvar produto:", err);
-          alert("Erro ao salvar produto.");
+          if (!err?.displayed) {
+            alert("Erro ao salvar produto.");
+          }
         }
       };
 
@@ -168,18 +234,27 @@
       }
 
       window.updateStock = async (id, delta) => {
-        const ref = db.collection("products").doc(id);
-        const snap = await ref.get();
-        if (!snap.exists) return;
-        const stock = (snap.data().stock || 0) + delta;
-        await ref.update({ stock: Math.max(stock,0) });
-        loadProducts();
+        try {
+          await callProductsApi("PATCH", { id, delta });
+          loadProducts();
+        } catch (err) {
+          console.error("Erro ao atualizar estoque:", err);
+          if (!err?.displayed) {
+            alert("Erro ao atualizar estoque.");
+          }
+        }
       };
 
       window.deleteProduct = async (id) => {
-        if (confirm("Excluir produto?")) {
-          await db.collection("products").doc(id).delete();
+        if (!confirm("Excluir produto?")) return;
+        try {
+          await callProductsApi("DELETE", { id });
           loadProducts();
+        } catch (err) {
+          console.error("Erro ao excluir produto:", err);
+          if (!err?.displayed) {
+            alert("Erro ao excluir produto.");
+          }
         }
       };
 

--- a/duo-parfum-pro/api/products.js
+++ b/duo-parfum-pro/api/products.js
@@ -1,0 +1,221 @@
+const admin = require("firebase-admin");
+
+const ADMIN_EMAILS = (process.env.ADMIN_EMAILS || "guilhermeserraglio03@gmail.com")
+  .split(",")
+  .map((email) => email.trim().toLowerCase())
+  .filter(Boolean);
+
+function initializeFirebaseAdmin() {
+  if (admin.apps.length) {
+    return;
+  }
+
+  const projectId = process.env.FIREBASE_PROJECT_ID;
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY
+    ? process.env.FIREBASE_PRIVATE_KEY.replace(/\\n/g, "\n")
+    : undefined;
+
+  if (!projectId || !clientEmail || !privateKey) {
+    throw new Error("Credenciais do Firebase Admin não configuradas");
+  }
+
+  admin.initializeApp({
+    credential: admin.credential.cert({
+      projectId,
+      clientEmail,
+      privateKey,
+    }),
+  });
+}
+
+function parseBody(body) {
+  if (!body) return {};
+  if (typeof body === "string") {
+    try {
+      return JSON.parse(body);
+    } catch (err) {
+      console.error("Falha ao interpretar corpo da requisição:", err);
+      return {};
+    }
+  }
+  return body;
+}
+
+async function authenticateRequest(req) {
+  const authHeader = req.headers?.authorization || "";
+  const match = authHeader.match(/^Bearer\s+(.+)$/i);
+
+  if (!match) {
+    const error = new Error("Token de autenticação ausente");
+    error.status = 401;
+    throw error;
+  }
+
+  const token = match[1].trim();
+  if (!token) {
+    const error = new Error("Token de autenticação ausente");
+    error.status = 401;
+    throw error;
+  }
+
+  let decoded;
+  try {
+    decoded = await admin.auth().verifyIdToken(token);
+  } catch (err) {
+    console.error("Falha ao verificar token do Firebase:", err);
+    const error = new Error("Token inválido ou expirado");
+    error.status = 401;
+    throw error;
+  }
+
+  const email = (decoded?.email || "").toLowerCase();
+  if (!email || !ADMIN_EMAILS.includes(email)) {
+    const error = new Error("Usuário não autorizado");
+    error.status = 403;
+    throw error;
+  }
+
+  return { email, uid: decoded.uid };
+}
+
+function sanitizeString(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+module.exports = async function handler(req, res) {
+  try {
+    initializeFirebaseAdmin();
+  } catch (err) {
+    console.error("Erro ao inicializar Firebase Admin:", err);
+    return res
+      .status(500)
+      .json({ error: "Configuração do servidor indisponível" });
+  }
+
+  if (!ADMIN_EMAILS.length) {
+    console.warn("Nenhum e-mail de administrador configurado");
+  }
+
+  const db = admin.firestore();
+
+  if (!["POST", "PATCH", "DELETE"].includes(req.method)) {
+    res.setHeader("Allow", "POST, PATCH, DELETE");
+    return res.status(405).json({ error: "Método não permitido" });
+  }
+
+  let user;
+  try {
+    user = await authenticateRequest(req);
+  } catch (err) {
+    const status = err.status || 401;
+    return res.status(status).json({ error: err.message || "Não autorizado" });
+  }
+
+  const payload = parseBody(req.body);
+
+  if (req.method === "POST") {
+    const name = sanitizeString(payload.name);
+    const brand = sanitizeString(payload.brand);
+    const ml = sanitizeString(payload.ml);
+    const notes = sanitizeString(payload.notes);
+    const category = sanitizeString(payload.category);
+    const image = sanitizeString(payload.image);
+    const featured = Boolean(payload.featured);
+
+    const priceValue = Number(payload.price);
+    if (!name) {
+      return res.status(400).json({ error: "Nome do produto é obrigatório" });
+    }
+    if (!Number.isFinite(priceValue) || priceValue < 0) {
+      return res.status(400).json({ error: "Preço inválido" });
+    }
+
+    const product = {
+      name,
+      brand,
+      ml,
+      price: Math.round(priceValue * 100) / 100,
+      notes,
+      category,
+      image,
+      stock: 0,
+      featured,
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      createdBy: user.email,
+    };
+
+    try {
+      const docRef = await db.collection("products").add(product);
+      return res.status(201).json({ id: docRef.id });
+    } catch (err) {
+      console.error("Erro ao criar produto:", err);
+      return res.status(500).json({ error: "Falha ao criar produto" });
+    }
+  }
+
+  if (req.method === "PATCH") {
+    const id = sanitizeString(payload.id);
+    const deltaValue = Number(payload.delta);
+
+    if (!id) {
+      return res.status(400).json({ error: "ID do produto é obrigatório" });
+    }
+
+    if (!Number.isFinite(deltaValue)) {
+      return res.status(400).json({ error: "Variação de estoque inválida" });
+    }
+
+    const ref = db.collection("products").doc(id);
+
+    try {
+      let newStock = 0;
+      await db.runTransaction(async (transaction) => {
+        const snap = await transaction.get(ref);
+        if (!snap.exists) {
+          const error = new Error("Produto não encontrado");
+          error.status = 404;
+          throw error;
+        }
+        const currentStock = Number(snap.data()?.stock) || 0;
+        newStock = Math.max(currentStock + deltaValue, 0);
+        transaction.update(ref, {
+          stock: newStock,
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+          updatedBy: user.email,
+        });
+      });
+      return res.status(200).json({ id, stock: newStock });
+    } catch (err) {
+      if (err.status === 404) {
+        return res.status(404).json({ error: err.message });
+      }
+      console.error("Erro ao atualizar estoque:", err);
+      return res.status(500).json({ error: "Falha ao atualizar estoque" });
+    }
+  }
+
+  if (req.method === "DELETE") {
+    const id = sanitizeString(payload.id);
+    if (!id) {
+      return res.status(400).json({ error: "ID do produto é obrigatório" });
+    }
+
+    const ref = db.collection("products").doc(id);
+    try {
+      const snap = await ref.get();
+      if (!snap.exists) {
+        return res.status(404).json({ error: "Produto não encontrado" });
+      }
+      await ref.delete();
+      return res.status(200).json({ id });
+    } catch (err) {
+      console.error("Erro ao excluir produto:", err);
+      return res.status(500).json({ error: "Falha ao excluir produto" });
+    }
+  }
+
+  res.setHeader("Allow", "POST, PATCH, DELETE");
+  return res.status(405).json({ error: "Método não permitido" });
+};


### PR DESCRIPTION
## Summary
- add a Firebase Admin-backed `/api/products` endpoint that validates ID tokens and enforces admin access before writing to Firestore
- update the admin panel to use the new API for creating, updating, and deleting products while surfacing authorization errors to the user

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d32b4df3848330876d29f6175dc8f3