### PR TITLE
Melhora interface de pedidos no painel admin

### DIFF
--- a/duo-parfum-pro/admin.html
+++ b/duo-parfum-pro/admin.html
@@ -51,7 +51,7 @@
     <!-- Pedidos -->
     <section>
       <h3>Pedidos</h3>
-      <div id="orderList" class="grid"></div>
+      <div id="orderList" class="grid orders-grid"></div>
     </section>
   </main>
 
@@ -89,6 +89,23 @@
         orderList: document.getElementById("orderList"),
         btnLogout: document.getElementById("btnLogout")
       };
+
+      const ORDER_STATUS = {
+        pending: { key: "pending", label: "Pendente", className: "is-pending" },
+        paid: { key: "paid", label: "Pago", className: "is-paid" },
+        sent: { key: "sent", label: "Enviado", className: "is-sent" },
+        canceled: { key: "canceled", label: "Cancelado", className: "is-canceled" }
+      };
+
+      const formatCurrency = (value) => {
+        const amount = Number(value) || 0;
+        return amount.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+      };
+
+      function getOrderStatusInfo(status) {
+        const normalized = (status || "pending").toString().toLowerCase();
+        return ORDER_STATUS[normalized] || ORDER_STATUS.pending;
+      }
 
       async function callProductsApi(method, payload = {}) {
         const user = auth.currentUser;
@@ -262,35 +279,112 @@
 
       /* ==== Pedidos ==== */
       async function loadOrders() {
-        const snap = await db.collection("orders").orderBy("createdAt","desc").get();
+        const snap = await db.collection("orders").orderBy("createdAt", "desc").get();
         els.orderList.innerHTML = "";
+
+        if (snap.empty) {
+          els.orderList.innerHTML = '<div class="order-card__empty muted">Nenhum pedido registrado até o momento.</div>';
+          return;
+        }
+
         snap.forEach(doc => {
-          const d = doc.data();
+          const data = doc.data();
+          const statusInfo = getOrderStatusInfo(data.status);
           const card = document.createElement("div");
-          card.className = "card";
-          const items = d.items.map(i => `${i.qty}x ${i.name} ${i.ml||""}`).join("<br>");
+          card.className = `card order-card ${statusInfo.className}`;
+
+          const items = Array.isArray(data.items) ? data.items : [];
+          const itemsList = items
+            .map(item => {
+              const quantity = item?.qty || 1;
+              const name = item?.name || "Item";
+              const ml = item?.ml ? ` (${item.ml})` : "";
+              return `<li>${quantity}x ${name}${ml}</li>`;
+            })
+            .join("");
+
+          const contactLine = [data.customer?.email, data.customer?.phone].filter(Boolean).join(" · ");
+          const addressLine = [data.customer?.cep, data.customer?.address, data.customer?.city, data.customer?.state]
+            .filter(Boolean)
+            .join(" · ");
+          const createdAt = typeof data.createdAt?.toDate === "function" ? data.createdAt.toDate() : null;
+          const createdAtLine = createdAt ? `Realizado em ${createdAt.toLocaleString("pt-BR")}` : "";
+          const metaLines = [contactLine, addressLine, createdAtLine]
+            .filter(Boolean)
+            .map(line => `<p class="order-card__meta-line">${line}</p>`)
+            .join("");
+
+          const statusButtons = [
+            { value: "paid", label: "Pago" },
+            { value: "sent", label: "Enviado" },
+            { value: "canceled", label: "Cancelado" }
+          ];
+
+          const actionsHtml = statusButtons
+            .map(button => {
+              const isCurrent = button.value === statusInfo.key;
+              const activeClass = isCurrent ? " is-current" : "";
+              return `<button class="btn small ghost${activeClass}" onclick="updateOrder('${doc.id}','${button.value}')">${button.label}</button>`;
+            })
+            .join("");
+
           card.innerHTML = `
-            <div class="pad">
-              <div><strong>Cliente:</strong> ${d.customer?.name || ""}</div>
-              <div><strong>E-mail:</strong> ${d.customer?.email || ""}</div>
-              <div><strong>Endereço:</strong> ${d.customer?.cep || ""}, ${d.customer?.address || ""}</div>
-              <div><strong>Pagamento:</strong> ${d.customer?.payment || ""}</div>
-              <div><strong>Itens:</strong><br>${items}</div>
-              <div><strong>Total:</strong> ${(d.total||0).toLocaleString("pt-BR",{style:"currency",currency:"BRL"})}</div>
-              <div><strong>Status:</strong> ${d.status}</div>
-              <div class="row gap" style="margin-top:8px">
-                <button class="btn small" onclick="updateOrder('${doc.id}','paid')">Pago</button>
-                <button class="btn small" onclick="updateOrder('${doc.id}','sent')">Enviado</button>
-                <button class="btn small" onclick="updateOrder('${doc.id}','canceled')">Cancelado</button>
+            <div class="pad order-card__content">
+              <div class="order-card__header">
+                <div>
+                  <p class="order-card__title">${data.customer?.name || "Cliente"}</p>
+                  ${metaLines}
+                </div>
+                <span class="order-card__status-badge ${statusInfo.className}">${statusInfo.label}</span>
+              </div>
+              <div class="order-card__details">
+                <div>
+                  <span class="order-card__label">Pagamento</span>
+                  <span class="order-card__value">${data.customer?.payment || "Não informado"}</span>
+                </div>
+                <div>
+                  <span class="order-card__label">Total</span>
+                  <span class="order-card__value">${formatCurrency(data.total)}</span>
+                </div>
+              </div>
+              <div class="order-card__items">
+                <span class="order-card__label">Itens</span>
+                <ul>${itemsList || "<li class='muted'>Nenhum item registrado.</li>"}</ul>
+              </div>
+              <div class="order-card__actions">
+                <button class="btn small ghost danger" onclick="deleteOrder('${doc.id}')">Excluir</button>
+                <div class="order-card__actions-group">
+                  ${actionsHtml}
+                </div>
               </div>
             </div>`;
+
           els.orderList.appendChild(card);
         });
       }
 
       window.updateOrder = async (id, status) => {
-        await db.collection("orders").doc(id).update({ status });
-        loadOrders();
+        try {
+          await db.collection("orders").doc(id).update({ status });
+          loadOrders();
+        } catch (err) {
+          console.error("Erro ao atualizar pedido:", err);
+          alert("Não foi possível atualizar o status do pedido.");
+        }
+      };
+
+      window.deleteOrder = async (id) => {
+        if (!confirm("Excluir este pedido? Essa ação não poderá ser desfeita.")) {
+          return;
+        }
+
+        try {
+          await db.collection("orders").doc(id).delete();
+          loadOrders();
+        } catch (err) {
+          console.error("Erro ao excluir pedido:", err);
+          alert("Não foi possível excluir o pedido.");
+        }
       };
 
       loadOrders();

--- a/duo-parfum-pro/style.css
+++ b/duo-parfum-pro/style.css
@@ -213,6 +213,23 @@ button:disabled {
   font-size: 0.85rem;
 }
 
+.btn.ghost.is-current {
+  border-color: var(--brand-medium);
+  background: rgba(183, 132, 106, 0.16);
+  color: var(--brand-darker);
+}
+
+.btn.ghost.danger {
+  color: #b13838;
+  border-color: rgba(214, 69, 69, 0.4);
+}
+
+.btn.ghost.danger:hover,
+.btn.ghost.danger:focus-visible {
+  background: rgba(214, 69, 69, 0.12);
+  color: #8f2424;
+}
+
 #cartCount {
   background: rgba(255, 255, 255, 0.25);
   padding: 0.1rem 0.6rem;
@@ -421,6 +438,158 @@ button:disabled {
   gap: 22px;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   margin-top: 28px;
+}
+
+.orders-grid {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.order-card {
+  border-left: 6px solid rgba(140, 91, 77, 0.25);
+  position: relative;
+}
+
+.order-card__content {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.order-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.order-card__title {
+  font-weight: 600;
+  font-size: 1.08rem;
+  color: var(--brand-darker);
+  margin-bottom: 4px;
+}
+
+.order-card__meta-line {
+  font-size: 0.86rem;
+  color: var(--brand-muted);
+}
+
+.order-card__status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 1rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(140, 91, 77, 0.12);
+  color: var(--brand-darker);
+  white-space: nowrap;
+}
+
+.order-card__details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+  padding: 16px;
+  margin: -8px 0 0;
+  border-radius: 16px;
+  background: rgba(140, 91, 77, 0.06);
+}
+
+.order-card__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--brand-muted);
+}
+
+.order-card__value {
+  font-weight: 600;
+  color: var(--brand-darker);
+}
+
+.order-card__items {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.order-card__items ul {
+  list-style: disc;
+  padding-left: 20px;
+  display: grid;
+  gap: 6px;
+}
+
+.order-card__items li {
+  font-size: 0.92rem;
+  color: var(--brand-text);
+}
+
+.order-card__actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.order-card__actions-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.order-card__actions .btn {
+  white-space: nowrap;
+}
+
+.order-card__empty {
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 18px;
+  padding: 32px;
+  text-align: center;
+  width: 100%;
+  box-shadow: 0 12px 24px rgba(140, 91, 77, 0.08);
+}
+
+.order-card.is-paid {
+  border-left-color: #d4a017;
+  background: linear-gradient(140deg, rgba(255, 221, 118, 0.16), rgba(255, 249, 232, 0.85));
+}
+
+.order-card.is-sent {
+  border-left-color: #3b9d73;
+  background: linear-gradient(140deg, rgba(66, 174, 118, 0.16), rgba(233, 247, 242, 0.85));
+}
+
+.order-card.is-canceled {
+  border-left-color: #d64545;
+  background: linear-gradient(140deg, rgba(214, 69, 69, 0.14), rgba(253, 236, 234, 0.88));
+}
+
+.order-card__status-badge.is-paid {
+  background: rgba(255, 204, 0, 0.22);
+  color: #8a6d1f;
+}
+
+.order-card__status-badge.is-sent {
+  background: rgba(72, 175, 132, 0.22);
+  color: #2e7a53;
+}
+
+.order-card__status-badge.is-canceled {
+  background: rgba(214, 69, 69, 0.18);
+  color: #a93434;
+}
+
+.order-card__status-badge.is-pending {
+  background: rgba(140, 91, 77, 0.15);
+  color: var(--brand-darker);
 }
 
 .card {
@@ -718,6 +887,31 @@ hr {
 @media (max-width: 900px) {
   .hero {
     padding: 110px 0 90px;
+  }
+}
+
+@media (max-width: 720px) {
+  .order-card__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .order-card__status-badge {
+    margin-top: 8px;
+  }
+
+  .order-card__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .order-card__actions-group {
+    justify-content: flex-start;
+    width: 100%;
+  }
+
+  .order-card__actions-group .btn {
+    flex: 1 1 120px;
   }
 }
 


### PR DESCRIPTION
## Summary
- reorganiza os cards de pedidos para exibir dados do cliente, itens e ações de forma mais clara
- aplica cores específicas para os status Pago, Enviado e Cancelado e permite excluir pedidos
- adiciona estilos dedicados aos pedidos e estados dos botões para manter a identidade visual

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3305f24b48330870c158932a14bb8