### PR TITLE
feat: add customer orders section with Correios tracking

### DIFF
--- a/duo-parfum-pro/admin.html
+++ b/duo-parfum-pro/admin.html
@@ -102,6 +102,14 @@
         return amount.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
       };
 
+      const escapeHtml = (value = "") =>
+        value
+          .toString()
+          .replace(/[&<>"']/g, (match) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[match]));
+
+      const sanitizeTrackingCode = (code = "") =>
+        code.toString().toUpperCase().replace(/[^A-Z0-9]/g, "");
+
       function getOrderStatusInfo(status) {
         const normalized = (status || "pending").toString().toLowerCase();
         return ORDER_STATUS[normalized] || ORDER_STATUS.pending;
@@ -297,12 +305,13 @@
           const itemsList = items
             .map(item => {
               const quantity = item?.qty || 1;
-              const name = item?.name || "Item";
-              const ml = item?.ml ? ` (${item.ml})` : "";
+              const name = escapeHtml(item?.name || "Item");
+              const ml = item?.ml ? ` (${escapeHtml(item.ml)})` : "";
               return `<li>${quantity}x ${name}${ml}</li>`;
             })
             .join("");
 
+          const trackingCode = sanitizeTrackingCode(data.trackingCode || data.shipping?.trackingCode || "");
           const contactLine = [data.customer?.email, data.customer?.phone].filter(Boolean).join(" · ");
           const addressLine = [data.customer?.cep, data.customer?.address, data.customer?.city, data.customer?.state]
             .filter(Boolean)
@@ -311,8 +320,18 @@
           const createdAtLine = createdAt ? `Realizado em ${createdAt.toLocaleString("pt-BR")}` : "";
           const metaLines = [contactLine, addressLine, createdAtLine]
             .filter(Boolean)
-            .map(line => `<p class="order-card__meta-line">${line}</p>`)
+            .map(line => `<p class="order-card__meta-line">${escapeHtml(line)}</p>`)
             .join("");
+
+          const trackingHtml = `
+            <div class="order-card__tracking-admin">
+              <span class="order-card__label">Rastreio Correios</span>
+              <div class="order-card__tracking-actions">
+                <input class="input order-card__tracking-input" data-tracking-input="${doc.id}" placeholder="Ex: LB123456789BR" value="${escapeHtml(trackingCode)}">
+                <button class="btn small ghost" onclick="saveTracking('${doc.id}')">Salvar</button>
+                ${trackingCode ? `<a class="btn small ghost" href="https://rastreamento.correios.com.br/app/index.php?codigo=${trackingCode}" target="_blank" rel="noreferrer">Ver no Correios</a>` : ""}
+              </div>
+            </div>`;
 
           const statusButtons = [
             { value: "paid", label: "Pago" },
@@ -332,7 +351,7 @@
             <div class="pad order-card__content">
               <div class="order-card__header">
                 <div>
-                  <p class="order-card__title">${data.customer?.name || "Cliente"}</p>
+                  <p class="order-card__title">${escapeHtml(data.customer?.name || "Cliente")}</p>
                   ${metaLines}
                 </div>
                 <span class="order-card__status-badge ${statusInfo.className}">${statusInfo.label}</span>
@@ -340,7 +359,7 @@
               <div class="order-card__details">
                 <div>
                   <span class="order-card__label">Pagamento</span>
-                  <span class="order-card__value">${data.customer?.payment || "Não informado"}</span>
+                  <span class="order-card__value">${escapeHtml(data.customer?.payment || "Não informado")}</span>
                 </div>
                 <div>
                   <span class="order-card__label">Total</span>
@@ -351,6 +370,7 @@
                 <span class="order-card__label">Itens</span>
                 <ul>${itemsList || "<li class='muted'>Nenhum item registrado.</li>"}</ul>
               </div>
+              ${trackingHtml}
               <div class="order-card__actions">
                 <button class="btn small ghost danger" onclick="deleteOrder('${doc.id}')">Excluir</button>
                 <div class="order-card__actions-group">
@@ -370,6 +390,30 @@
         } catch (err) {
           console.error("Erro ao atualizar pedido:", err);
           alert("Não foi possível atualizar o status do pedido.");
+        }
+      };
+
+      window.saveTracking = async (id) => {
+        const input = document.querySelector(`[data-tracking-input="${id}"]`);
+        if (!input) {
+          alert("Campo de rastreio não encontrado.");
+          return;
+        }
+
+        const sanitized = sanitizeTrackingCode(input.value || "");
+        input.value = sanitized;
+
+        const updatePayload = sanitized
+          ? { trackingCode: sanitized }
+          : { trackingCode: firebase.firestore.FieldValue.delete() };
+
+        try {
+          await db.collection("orders").doc(id).update(updatePayload);
+          alert(sanitized ? "Código de rastreio atualizado." : "Código de rastreio removido.");
+          loadOrders();
+        } catch (err) {
+          console.error("Erro ao salvar código de rastreio:", err);
+          alert("Não foi possível atualizar o código de rastreio.");
         }
       };
 

--- a/duo-parfum-pro/api/tracking.js
+++ b/duo-parfum-pro/api/tracking.js
@@ -1,0 +1,156 @@
+const https = require("https");
+
+function sanitizeCode(code = "") {
+  return code.toString().toUpperCase().replace(/[^A-Z0-9]/g, "");
+}
+
+function fetchCorreiosTracking(code) {
+  const url = `https://proxyapp.correios.com.br/v1/sro-rastro/${encodeURIComponent(code)}`;
+  return new Promise((resolve, reject) => {
+    const req = https.get(url, { timeout: 10000 }, (res) => {
+      let raw = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk) => {
+        raw += chunk;
+      });
+      res.on("end", () => {
+        let data = {};
+        if (raw) {
+          try {
+            data = JSON.parse(raw);
+          } catch (err) {
+            if (res.statusCode >= 200 && res.statusCode < 300) {
+              return reject(new Error("Resposta inválida dos Correios"));
+            }
+            data = {};
+          }
+        }
+
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+          const message = data?.mensagem || data?.message || `Correios HTTP ${res.statusCode}`;
+          const error = new Error(message);
+          error.status = res.statusCode;
+          error.details = data;
+          return reject(error);
+        }
+
+        resolve(data || {});
+      });
+    });
+
+    req.on("error", (err) => {
+      reject(err);
+    });
+
+    req.on("timeout", () => {
+      req.destroy();
+      reject(new Error("Tempo excedido na consulta aos Correios"));
+    });
+  });
+}
+
+function normalizeLocation(unidade = {}, destino = {}) {
+  const parts = [];
+  const origemParts = [];
+  if (unidade.local) origemParts.push(unidade.local);
+  const origemCidade = [unidade.cidade, unidade.uf].filter(Boolean).join(" - ");
+  if (origemCidade) origemParts.push(origemCidade);
+  if (origemParts.length) parts.push(origemParts.join(" • "));
+
+  const destinoParts = [];
+  if (destino.local) destinoParts.push(destino.local);
+  const destinoCidade = [destino.cidade, destino.uf].filter(Boolean).join(" - ");
+  if (destinoCidade) destinoParts.push(destinoCidade);
+  if (destinoParts.length) {
+    const destinoText = destinoParts.join(" • ");
+    if (parts.length) {
+      parts.push(`Destino: ${destinoText}`);
+    } else {
+      parts.push(destinoText);
+    }
+  }
+
+  return parts.join(" · ");
+}
+
+function toIsoString(value) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toISOString();
+}
+
+function normalizeEvent(event = {}) {
+  const description = event.descricao || event.description || "";
+  const status = event.status || description;
+  const details = event.detalhe || event.detalhes || event.details || "";
+  const timestamp = toIsoString(event.dtHrCriado || event.dataHora || event.horario);
+  let date = event.data || "";
+  let time = event.hora || "";
+  if ((!date || !time) && timestamp) {
+    const dt = new Date(timestamp);
+    if (!Number.isNaN(dt.getTime())) {
+      if (!date) date = dt.toISOString().slice(0, 10);
+      if (!time) time = dt.toISOString().slice(11, 16);
+    }
+  }
+  const location = normalizeLocation(event.unidade || {}, event.unidadeDestino || {});
+
+  return {
+    code: event.codigo || event.cod || "",
+    status: status || "",
+    description: description || "",
+    details: details || "",
+    date,
+    time,
+    timestamp,
+    location,
+    raw: event,
+  };
+}
+
+function normalizeCorreiosData(code, payload = {}) {
+  const objetos = Array.isArray(payload.objetos) ? payload.objetos : [];
+  const normalizedCode = sanitizeCode(code);
+  const objeto =
+    objetos.find((item) => sanitizeCode(item?.codObjeto) === normalizedCode) || objetos[0] || {};
+  const events = Array.isArray(objeto.eventos) ? objeto.eventos.map(normalizeEvent) : [];
+  const filteredEvents = events.filter(Boolean);
+  filteredEvents.sort((a, b) => {
+    const timeA = a.timestamp ? new Date(a.timestamp).getTime() : 0;
+    const timeB = b.timestamp ? new Date(b.timestamp).getTime() : 0;
+    return timeB - timeA;
+  });
+
+  return {
+    code: sanitizeCode(objeto.codObjeto || normalizedCode),
+    events: filteredEvents,
+    raw: objeto,
+  };
+}
+
+module.exports = async function handler(req, res) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ error: "Método não permitido" });
+  }
+
+  const queryCode = Array.isArray(req.query?.code) ? req.query.code[0] : req.query?.code;
+  const bodyCode = Array.isArray(req.body?.code) ? req.body.code[0] : req.body?.code;
+  const code = sanitizeCode(queryCode || bodyCode || "");
+
+  if (!code) {
+    return res.status(400).json({ error: "Código de rastreio inválido" });
+  }
+
+  try {
+    const raw = await fetchCorreiosTracking(code);
+    const result = normalizeCorreiosData(code, raw);
+    res.setHeader("Cache-Control", "s-maxage=300, stale-while-revalidate=600");
+    return res.status(200).json(result);
+  } catch (err) {
+    console.error("Erro ao consultar rastreio dos Correios:", err);
+    const message = err?.message || "Falha ao consultar os Correios";
+    return res.status(502).json({ error: message });
+  }
+};

--- a/duo-parfum-pro/index.html
+++ b/duo-parfum-pro/index.html
@@ -31,6 +31,7 @@
       </a>
       <nav class="row gap">
         <a class="nav-link" href="#catalogo">Catálogo</a>
+        <a id="linkOrders" class="nav-link hidden" href="#meusPedidos">Meus pedidos</a>
         <button id="btnLogin" class="btn ghost">Entrar</button>
         <button id="btnLogout" class="btn ghost hidden">Sair</button>
         <a id="linkAdmin" href="/admin.html" class="btn ghost hidden">Admin</a>
@@ -105,6 +106,27 @@
 
       <div id="emptyState" class="muted hidden">Nenhum produto encontrado.</div>
       <div id="grid" class="grid"></div>
+    </div>
+  </section>
+
+  <!-- Meus pedidos -->
+  <section id="meusPedidos" class="orders-section">
+    <div class="container">
+      <header class="section-head">
+        <span class="section-eyebrow">Acompanhe seu pedido</span>
+        <h2>Meus pedidos</h2>
+        <p>Veja o status do pagamento, envio e o rastreio integrado aos Correios.</p>
+      </header>
+
+      <div id="ordersGuest" class="orders-guest">
+        <h3>Faça login para acompanhar seus pedidos</h3>
+        <p class="muted">Use o botão "Entrar" no topo da página para visualizar seus pedidos e acompanhar o envio.</p>
+      </div>
+
+      <div id="ordersError" class="orders-error hidden"></div>
+      <div id="ordersLoading" class="muted hidden">Carregando seus pedidos...</div>
+      <div id="ordersEmpty" class="muted hidden">Você ainda não possui pedidos registrados.</div>
+      <div id="ordersList" class="grid orders-grid hidden"></div>
     </div>
   </section>
 

--- a/duo-parfum-pro/style.css
+++ b/duo-parfum-pro/style.css
@@ -440,6 +440,34 @@ button:disabled {
   margin-top: 28px;
 }
 
+.orders-section {
+  padding: 80px 0;
+}
+
+.orders-guest {
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px dashed rgba(140, 91, 77, 0.35);
+  border-radius: 18px;
+  padding: 26px;
+  margin-top: 28px;
+  box-shadow: 0 12px 28px rgba(140, 91, 77, 0.06);
+}
+
+.orders-guest h3 {
+  font-size: 1.1rem;
+  margin-bottom: 6px;
+}
+
+.orders-error {
+  margin-top: 24px;
+  padding: 16px 20px;
+  border-radius: 14px;
+  background: rgba(214, 69, 69, 0.12);
+  border: 1px solid rgba(214, 69, 69, 0.35);
+  color: #8f2424;
+  font-weight: 500;
+}
+
 .orders-grid {
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
@@ -535,6 +563,123 @@ button:disabled {
   align-items: center;
   gap: 12px;
   flex-wrap: wrap;
+}
+
+.order-card__tracking,
+.order-card__tracking-admin {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.order-card__tracking-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.order-card__tracking-input {
+  flex: 1 1 220px;
+  min-width: 180px;
+}
+
+.order-tracking {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.order-tracking__code {
+  font-weight: 600;
+  color: var(--brand-darker);
+}
+
+.order-tracking__status {
+  font-size: 0.95rem;
+  color: var(--brand-text);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.order-tracking__event {
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: rgba(140, 91, 77, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.order-tracking__event-head {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.order-tracking__event-head strong {
+  font-size: 0.95rem;
+  color: var(--brand-darker);
+}
+
+.order-tracking__event-head span {
+  font-size: 0.8rem;
+  color: var(--brand-muted);
+}
+
+.order-tracking__event p {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.order-tracking__history {
+  background: rgba(255, 255, 255, 0.82);
+  border-radius: 12px;
+  padding: 12px 14px;
+  border: 1px solid rgba(140, 91, 77, 0.16);
+}
+
+.order-tracking__history summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--brand-darker);
+  list-style: none;
+}
+
+.order-tracking__history summary::-webkit-details-marker {
+  display: none;
+}
+
+.order-tracking__history summary::after {
+  content: "▼";
+  font-size: 0.7rem;
+  margin-left: 8px;
+  transition: transform 0.2s ease;
+  display: inline-block;
+}
+
+.order-tracking__history[open] summary::after {
+  transform: rotate(180deg);
+}
+
+.order-tracking__history ul {
+  list-style: none;
+  margin-top: 12px;
+  display: grid;
+  gap: 10px;
+  padding-left: 0;
+}
+
+.order-tracking__history li {
+  font-size: 0.9rem;
+  line-height: 1.4;
+  color: var(--brand-text);
+}
+
+.order-tracking__history li span {
+  display: block;
+  font-size: 0.78rem;
+  color: var(--brand-muted);
 }
 
 .order-card__actions-group {


### PR DESCRIPTION
## Summary
- add a "Meus pedidos" area on the storefront that listens to Firestore orders for the logged in customer and surfaces Correios tracking updates
- expose an `/api/tracking` endpoint that queries the Correios API, normalizes the events and feeds the frontend tracking UI
- enhance the admin panel to manage sanitized tracking codes for orders and expand styling to cover the new customer and admin order states

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d338aeb8c48330b65e041217a439c2