### PR TITLE
Fix orders section id to display customer orders

### DIFF
--- a/duo-parfum-pro/index.html
+++ b/duo-parfum-pro/index.html
@@ -31,7 +31,7 @@
       </a>
       <nav class="row gap">
         <a class="nav-link" href="#catalogo">Catálogo</a>
-        <a id="linkOrders" class="nav-link hidden" href="#meusPedidos">Meus pedidos</a>
+        <a id="linkOrders" class="nav-link hidden" href="#ordersSection">Meus pedidos</a>
         <button id="btnLogin" class="btn ghost">Entrar</button>
         <button id="btnLogout" class="btn ghost hidden">Sair</button>
         <a id="linkAdmin" href="/admin.html" class="btn ghost hidden">Admin</a>
@@ -110,7 +110,7 @@
   </section>
 
   <!-- Meus pedidos -->
-  <section id="meusPedidos" class="orders-section">
+  <section id="ordersSection" class="orders-section">
     <div class="container">
       <header class="section-head">
         <span class="section-eyebrow">Acompanhe seu pedido</span>


### PR DESCRIPTION
## Summary
- update the "Meus pedidos" navigation anchor to point to #ordersSection
- rename the orders section id so the frontend script detects and renders the logged-in customer's orders

## Testing
- not run (static frontend change)


------
https://chatgpt.com/codex/tasks/task_e_68d340d0eb948330bbe3c64fbcb63722