### PR TITLE
Remove stock controls from admin product cards

### DIFF
--- a/duo-parfum-pro/admin.html
+++ b/duo-parfum-pro/admin.html
@@ -308,8 +308,6 @@
           const data = doc.data() || {};
           const rawPrice = Number(data.price);
           const hasValidPrice = Number.isFinite(rawPrice);
-          const rawStock = Number(data.stock);
-          const normalizedStock = Number.isFinite(rawStock) ? rawStock : 0;
           const product = {
             id: doc.id,
             name: data.name || "",
@@ -319,7 +317,6 @@
             notes: data.notes || "",
             category: data.category || "",
             image: data.image || "",
-            stock: Math.max(normalizedStock, 0),
             featured: data.featured
           };
 
@@ -343,10 +340,7 @@
               <div class="muted">${escapeHtml(priceLabel)}</div>
               ${categoryLine}
               ${notesLine}
-              <div class="muted">Estoque: ${product.stock}</div>
               <div class="row gap" style="margin-top:8px">
-                <button class="btn small" onclick="updateStock('${product.id}',1)">+1</button>
-                <button class="btn small" onclick="updateStock('${product.id}',-1)">-1</button>
                 <button class="btn small" onclick="editProduct('${product.id}')">Editar</button>
                 <button class="btn small" onclick="deleteProduct('${product.id}')">Excluir</button>
               </div>
@@ -354,18 +348,6 @@
           els.productList.appendChild(card);
         });
       }
-
-      window.updateStock = async (id, delta) => {
-        try {
-          await callProductsApi("PATCH", { id, delta });
-          loadProducts();
-        } catch (err) {
-          console.error("Erro ao atualizar estoque:", err);
-          if (!err?.displayed) {
-            alert("Erro ao atualizar estoque.");
-          }
-        }
-      };
 
       window.deleteProduct = async (id) => {
         if (!confirm("Excluir produto?")) return;


### PR DESCRIPTION
## Summary
- remove the stock display and +/- adjustment buttons from each admin product card
- delete the unused updateStock helper that called the products API with a stock delta

## Testing
- not run (Firebase services unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d35316c07483309ef97b78180acdb4