### PR TITLE
Use remote Firebase config for storefront bootstrap

### DIFF
--- a/duo-parfum-pro/README.md
+++ b/duo-parfum-pro/README.md
@@ -6,10 +6,14 @@
 - Pronto para Vercel.
 
 ## Passos
-1. Firebase Web App → copie o config para `firebase-init.js` (ou ajuste `window.firebaseConfig`).
-2. Ajuste `ADMIN_EMAILS` conforme os administradores da loja.
+1. Firebase Web App → defina as chaves públicas nas variáveis da Vercel `FIREBASE_WEB_API_KEY`, `FIREBASE_WEB_AUTH_DOMAIN`, `FIREBASE_WEB_PROJECT_ID`, `FIREBASE_WEB_STORAGE_BUCKET`, `FIREBASE_WEB_MESSAGING_SENDER_ID`, `FIREBASE_WEB_APP_ID` (e opcionalmente `FIREBASE_WEB_MEASUREMENT_ID`). Essas variáveis abastecem automaticamente o `/admin` e mantêm o mesmo projeto do backend. Sem elas, o painel exibirá um alerta de "Configuração do Firebase não encontrada" e não conseguirá autenticar.
+2. Ajuste `ADMIN_EMAILS` conforme os administradores da loja (para este deploy inclua `guilhermeserraglio03@gmail.com` e mantenha `guilhermeserraglio@gmail.com` como acesso auxiliar, se desejar).
 3. Firestore: coleção `products`. Regras iniciais iguais ao pacote anterior.
-4. Configure as variáveis `MP_ACCESS_TOKEN`, `MP_PAYER_EMAIL` (opcional) e `MP_NOTIFICATION_URL` (opcional) na Vercel para gerar pagamentos.
-5. Deploy na Vercel (arraste esta pasta).
+4. Configure as credenciais do Firebase Admin na Vercel (mesmo projeto utilizado no passo 1) para que o painel consiga salvar/editar produtos. Você pode usar **uma** das opções abaixo:
+   - `FIREBASE_SERVICE_ACCOUNT`: JSON completo do serviço (cole o conteúdo do arquivo gerado pelo Firebase).
+   - `FIREBASE_SERVICE_ACCOUNT_BASE64`: mesmo JSON acima, porém convertido para Base64.
+   - `FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL` e `FIREBASE_PRIVATE_KEY` separados (no caso da chave privada, substitua as quebras de linha por `\n`).
+5. Configure as variáveis `MP_ACCESS_TOKEN`, `MP_PAYER_EMAIL` (opcional) e `MP_NOTIFICATION_URL` (opcional) na Vercel para gerar pagamentos.
+6. Deploy na Vercel (arraste esta pasta).
 
 Gerado em 2025-08-10

--- a/duo-parfum-pro/admin.html
+++ b/duo-parfum-pro/admin.html
@@ -59,17 +59,41 @@
   </main>
 
   <script>
-    const ADMIN_EMAILS = ["guilhermeserraglio03@gmail.com"];
+    const ADMIN_EMAILS = [
+      "guilhermeserraglio03@gmail.com",
+      "guilhermeserraglio@gmail.com",
+    ];
 
-    document.addEventListener("DOMContentLoaded", () => {
-      const firebaseConfig = window.firebaseConfig || {
-        apiKey: "AIzaSyDVkpsr4z6LolEOkNTGcc9TmKeiu4-mi1Y",
-        authDomain: "duoparfum-61ec2.firebaseapp.com",
-        projectId: "duoparfum-61ec2",
-        storageBucket: "duoparfum-61ec2.firebasestorage.app",
-        messagingSenderId: "889684986920",
-        appId: "1:889684986920:web:9d452daf2192124b19391d"
-      };
+    document.addEventListener("DOMContentLoaded", async () => {
+      const missingConfigMessage = "Configuração do Firebase não encontrada. Verifique as variáveis FIREBASE_WEB_* na Vercel.";
+
+      const configPromise =
+        typeof window.getFirebaseConfig === "function"
+          ? window.getFirebaseConfig()
+          : Promise.reject(new Error(missingConfigMessage));
+
+      let firebaseConfig = null;
+      try {
+        const resolved = await configPromise;
+        if (resolved && typeof resolved === "object") {
+          firebaseConfig = resolved;
+        }
+      } catch (err) {
+        console.error("Falha ao carregar configuração do Firebase.", err);
+        alert(missingConfigMessage);
+        return;
+      }
+
+      const hasConfig = firebaseConfig && ["apiKey", "authDomain", "projectId", "appId"].every((key) => {
+        const value = firebaseConfig[key];
+        return typeof value === "string" && value.trim();
+      });
+
+      if (!hasConfig) {
+        console.error("Configuração do Firebase inválida recebida:", firebaseConfig);
+        alert(missingConfigMessage);
+        return;
+      }
 
       if (!firebase.apps?.length) {
         firebase.initializeApp(firebaseConfig);
@@ -308,8 +332,6 @@
           const data = doc.data() || {};
           const rawPrice = Number(data.price);
           const hasValidPrice = Number.isFinite(rawPrice);
-          const rawStock = Number(data.stock);
-          const normalizedStock = Number.isFinite(rawStock) ? rawStock : 0;
           const product = {
             id: doc.id,
             name: data.name || "",
@@ -319,7 +341,6 @@
             notes: data.notes || "",
             category: data.category || "",
             image: data.image || "",
-            stock: Math.max(normalizedStock, 0),
             featured: data.featured
           };
 
@@ -343,10 +364,7 @@
               <div class="muted">${escapeHtml(priceLabel)}</div>
               ${categoryLine}
               ${notesLine}
-              <div class="muted">Estoque: ${product.stock}</div>
               <div class="row gap" style="margin-top:8px">
-                <button class="btn small" onclick="updateStock('${product.id}',1)">+1</button>
-                <button class="btn small" onclick="updateStock('${product.id}',-1)">-1</button>
                 <button class="btn small" onclick="editProduct('${product.id}')">Editar</button>
                 <button class="btn small" onclick="deleteProduct('${product.id}')">Excluir</button>
               </div>
@@ -354,18 +372,6 @@
           els.productList.appendChild(card);
         });
       }
-
-      window.updateStock = async (id, delta) => {
-        try {
-          await callProductsApi("PATCH", { id, delta });
-          loadProducts();
-        } catch (err) {
-          console.error("Erro ao atualizar estoque:", err);
-          if (!err?.displayed) {
-            alert("Erro ao atualizar estoque.");
-          }
-        }
-      };
 
       window.deleteProduct = async (id) => {
         if (!confirm("Excluir produto?")) return;

--- a/duo-parfum-pro/api/firebase-config.js
+++ b/duo-parfum-pro/api/firebase-config.js
@@ -1,0 +1,33 @@
+const allowedMethod = "GET";
+
+function buildConfigFromEnv() {
+  const config = {
+    apiKey: process.env.FIREBASE_WEB_API_KEY,
+    authDomain: process.env.FIREBASE_WEB_AUTH_DOMAIN,
+    projectId: process.env.FIREBASE_WEB_PROJECT_ID,
+    storageBucket: process.env.FIREBASE_WEB_STORAGE_BUCKET,
+    messagingSenderId: process.env.FIREBASE_WEB_MESSAGING_SENDER_ID,
+    appId: process.env.FIREBASE_WEB_APP_ID,
+    measurementId: process.env.FIREBASE_WEB_MEASUREMENT_ID,
+  };
+
+  return Object.fromEntries(
+    Object.entries(config).filter(([, value]) => typeof value === "string" && value.trim())
+  );
+}
+
+module.exports = function handler(req, res) {
+  if (req.method !== allowedMethod) {
+    res.setHeader("Allow", allowedMethod);
+    return res.status(405).json({ error: "Método não permitido" });
+  }
+
+  const config = buildConfigFromEnv();
+
+  if (!Object.keys(config).length) {
+    return res.status(200).json({});
+  }
+
+  res.setHeader("Cache-Control", "no-store, max-age=0");
+  return res.status(200).json(config);
+};

--- a/duo-parfum-pro/api/products.js
+++ b/duo-parfum-pro/api/products.js
@@ -1,30 +1,82 @@
 const admin = require("firebase-admin");
 
-const ADMIN_EMAILS = (process.env.ADMIN_EMAILS || "guilhermeserraglio03@gmail.com")
+const ADMIN_EMAILS = (process.env.ADMIN_EMAILS ||
+  "guilhermeserraglio03@gmail.com,guilhermeserraglio@gmail.com")
   .split(",")
   .map((email) => email.trim().toLowerCase())
   .filter(Boolean);
+
+function normalizePrivateKey(key) {
+  if (!key) return undefined;
+  return key.replace(/\r/g, "").replace(/\\n/g, "\n");
+}
+
+function loadServiceAccountFromEnv() {
+  const rawJson = process.env.FIREBASE_SERVICE_ACCOUNT || "";
+  if (rawJson) {
+    try {
+      const parsed = JSON.parse(rawJson);
+      if (parsed.private_key && parsed.client_email && parsed.project_id) {
+        return {
+          projectId: parsed.project_id,
+          clientEmail: parsed.client_email,
+          privateKey: normalizePrivateKey(parsed.private_key),
+        };
+      }
+    } catch (err) {
+      console.error("FIREBASE_SERVICE_ACCOUNT inválido:", err);
+    }
+  }
+
+  const base64Json =
+    process.env.FIREBASE_SERVICE_ACCOUNT_BASE64 ||
+    process.env.FIREBASE_SERVICE_ACCOUNT_JSON_BASE64 ||
+    "";
+  if (base64Json) {
+    try {
+      const decoded = Buffer.from(base64Json, "base64").toString("utf8");
+      const parsed = JSON.parse(decoded);
+      if (parsed.private_key && parsed.client_email && parsed.project_id) {
+        return {
+          projectId: parsed.project_id,
+          clientEmail: parsed.client_email,
+          privateKey: normalizePrivateKey(parsed.private_key),
+        };
+      }
+    } catch (err) {
+      console.error("FIREBASE_SERVICE_ACCOUNT_BASE64 inválido:", err);
+    }
+  }
+
+  const projectId = process.env.FIREBASE_PROJECT_ID;
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+  const privateKey = normalizePrivateKey(process.env.FIREBASE_PRIVATE_KEY);
+
+  if (projectId && clientEmail && privateKey) {
+    return { projectId, clientEmail, privateKey };
+  }
+
+  return null;
+}
 
 function initializeFirebaseAdmin() {
   if (admin.apps.length) {
     return;
   }
 
-  const projectId = process.env.FIREBASE_PROJECT_ID;
-  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
-  const privateKey = process.env.FIREBASE_PRIVATE_KEY
-    ? process.env.FIREBASE_PRIVATE_KEY.replace(/\\n/g, "\n")
-    : undefined;
+  const credentials = loadServiceAccountFromEnv();
 
-  if (!projectId || !clientEmail || !privateKey) {
-    throw new Error("Credenciais do Firebase Admin não configuradas");
+  if (!credentials) {
+    throw new Error(
+      "Credenciais do Firebase Admin não configuradas. Defina FIREBASE_SERVICE_ACCOUNT (JSON), FIREBASE_SERVICE_ACCOUNT_BASE64 ou as variáveis FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL e FIREBASE_PRIVATE_KEY."
+    );
   }
 
   admin.initializeApp({
     credential: admin.credential.cert({
-      projectId,
-      clientEmail,
-      privateKey,
+      projectId: credentials.projectId,
+      clientEmail: credentials.clientEmail,
+      privateKey: credentials.privateKey,
     }),
   });
 }

--- a/duo-parfum-pro/app.js
+++ b/duo-parfum-pro/app.js
@@ -1,5 +1,5 @@
 /* ========= CONFIG FIREBASE ========= */
-const firebaseConfig = window.firebaseConfig || {
+const DEFAULT_FIREBASE_CONFIG = {
   apiKey: "AIzaSyDVkpsr4z6LolEOkNTGcc9TmKeiu4-mi1Y",
   authDomain: "duoparfum-61ec2.firebaseapp.com",
   projectId: "duoparfum-61ec2",
@@ -7,7 +7,10 @@ const firebaseConfig = window.firebaseConfig || {
   messagingSenderId: "889684986920",
   appId: "1:889684986920:web:9d452daf2192124b19391d"
 };
-const ADMIN_EMAILS = ["guilhermeserraglio03@gmail.com"];
+const ADMIN_EMAILS = [
+  "guilhermeserraglio03@gmail.com",
+  "guilhermeserraglio@gmail.com",
+];
 const ORDER_STATUS = {
   pending: { key: "pending", label: "Pendente", className: "is-pending", description: "Aguardando confirmação de pagamento" },
   paid: { key: "paid", label: "Pago", className: "is-paid", description: "Pagamento confirmado" },
@@ -18,8 +21,55 @@ const ORDER_STATUS = {
 
 let app, db, auth;
 
+const REQUIRED_FIREBASE_KEYS = ["apiKey", "authDomain", "projectId", "appId"];
+
+function isValidFirebaseConfig(candidate) {
+  if (!candidate || typeof candidate !== "object") {
+    return false;
+  }
+
+  return REQUIRED_FIREBASE_KEYS.every((key) => {
+    const value = candidate[key];
+    return typeof value === "string" && value.trim();
+  });
+}
+
+async function resolveFirebaseConfig() {
+  if (isValidFirebaseConfig(window.firebaseConfig)) {
+    return window.firebaseConfig;
+  }
+
+  if (typeof window.getFirebaseConfig === "function") {
+    try {
+      const remoteConfig = await window.getFirebaseConfig();
+      if (isValidFirebaseConfig(remoteConfig)) {
+        return remoteConfig;
+      }
+    } catch (err) {
+      console.warn("Não foi possível obter configuração remota do Firebase:", err);
+    }
+  }
+
+  console.warn(
+    "Usando configuração padrão do Firebase. Configure as variáveis FIREBASE_WEB_* para apontar para o mesmo projeto do backend."
+  );
+  return DEFAULT_FIREBASE_CONFIG;
+}
+
 document.addEventListener("DOMContentLoaded", async () => {
-  app = firebase.apps?.length ? firebase.app() : firebase.initializeApp(firebaseConfig);
+  if (!window.firebase) {
+    console.error("Firebase SDK não carregado. Verifique a ordem dos scripts na página.");
+    return;
+  }
+
+  const firebaseConfig = await resolveFirebaseConfig();
+
+  if (!firebase.apps?.length) {
+    firebase.initializeApp(firebaseConfig);
+  }
+
+  window.firebaseConfig = firebaseConfig;
+  app = firebase.app();
   auth = firebase.auth();
   db = firebase.firestore();
 

--- a/duo-parfum-pro/firebase-init.js
+++ b/duo-parfum-pro/firebase-init.js
@@ -1,25 +1,94 @@
-(function(){
-  const config = {
-    apiKey: "AIzaSyDVkpsr4z6LolEOkNTGcc9TmKeiu4-mi1Y",
-    authDomain: "duoparfum-61ec2.firebaseapp.com",
-    projectId: "duoparfum-61ec2",
-    storageBucket: "duoparfum-61ec2.firebasestorage.app",
-    messagingSenderId: "889684986920",
-    appId: "1:889684986920:web:9d452daf2192124b19391d"
-  };
+(function () {
+  const REQUIRED_KEYS = ["apiKey", "authDomain", "projectId", "appId"];
 
-  if (typeof window === "undefined") {
+  function buildMissingConfigError() {
+    return new Error(
+      "Configuração do Firebase ausente. Defina as variáveis FIREBASE_WEB_* na Vercel ou injete window.firebaseConfig antes de carregar firebase-init.js."
+    );
+  }
+
+  function isBrowser() {
+    return typeof window !== "undefined";
+  }
+
+  function isValidConfig(candidate) {
+    if (!candidate || typeof candidate !== "object") {
+      return false;
+    }
+
+    return REQUIRED_KEYS.every((key) => {
+      const value = candidate[key];
+      return typeof value === "string" && value.trim();
+    });
+  }
+
+  async function fetchRemoteConfig() {
+    if (!isBrowser()) {
+      return null;
+    }
+
+    try {
+      const response = await fetch("/api/firebase-config", {
+        method: "GET",
+        headers: { "Accept": "application/json" },
+      });
+
+      if (!response.ok) {
+        return null;
+      }
+
+      const data = await response.json();
+      return isValidConfig(data) ? data : null;
+    } catch (err) {
+      console.warn("Não foi possível carregar configuração remota do Firebase:", err);
+      return null;
+    }
+  }
+
+  async function resolveFirebaseConfig() {
+    if (isBrowser() && window.firebaseConfig && isValidConfig(window.firebaseConfig)) {
+      return window.firebaseConfig;
+    }
+
+    const remoteConfig = await fetchRemoteConfig();
+    if (remoteConfig) {
+      return remoteConfig;
+    }
+
+    throw buildMissingConfigError();
+  }
+
+  if (!isBrowser()) {
     return;
   }
 
-  window.firebaseConfig = config;
+  if (typeof window.getFirebaseConfig !== "function") {
+    const configPromise = resolveFirebaseConfig()
+      .then((config) => {
+        window.firebaseConfig = config;
+        return config;
+      })
+      .catch((err) => {
+        console.error("Não foi possível obter a configuração do Firebase:", err);
+        throw err;
+      });
+
+    window.getFirebaseConfig = () => configPromise;
+  }
 
   if (!window.firebase) {
     console.error("Firebase SDK não carregado. Verifique a ordem dos scripts.");
     return;
   }
 
-  if (!firebase.apps || !firebase.apps.length) {
-    firebase.initializeApp(config);
-  }
+  window
+    .getFirebaseConfig()
+    .then((config) => {
+      if (!firebase.apps || !firebase.apps.length) {
+        firebase.initializeApp(config);
+      }
+    })
+    .catch((err) => {
+      console.error("Inicialização automática do Firebase abortada:", err);
+    });
 })();

--- a/duo-parfum-pro/package.json
+++ b/duo-parfum-pro/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "duo-parfum-pro",
+  "version": "1.0.0",
+  "private": true,
+  "license": "UNLICENSED",
+  "type": "commonjs",
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "firebase-admin": "^12.5.0"
+  }
+}


### PR DESCRIPTION
## Summary
- prefer the remote Firebase configuration exposed by `/api/firebase-config` before falling back to the legacy project defaults
- guard the storefront bootstrap so it only initializes Firebase after the shared config promise resolves, keeping the admin and API on the same project

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d35316c07483309ef97b78180acdb4