### PR TITLE
Handle JSON-formatted ADMIN_EMAILS

### DIFF
--- a/duo-parfum-pro/README.md
+++ b/duo-parfum-pro/README.md
@@ -8,14 +8,7 @@
 ## Passos
 1. Firebase Web App → defina as chaves públicas nas variáveis da Vercel `FIREBASE_WEB_API_KEY`, `FIREBASE_WEB_AUTH_DOMAIN`, `FIREBASE_WEB_PROJECT_ID`, `FIREBASE_WEB_STORAGE_BUCKET`, `FIREBASE_WEB_MESSAGING_SENDER_ID`, `FIREBASE_WEB_APP_ID` (e opcionalmente `FIREBASE_WEB_MEASUREMENT_ID`). Essas variáveis abastecem automaticamente o `/admin` e mantêm o mesmo projeto do backend. Sem elas, o painel exibirá um alerta de "Configuração do Firebase não encontrada" e não conseguirá autenticar.
  c
-2. Ajuste `ADMIN_EMAILS` conforme os administradores da loja (para este deploy inclua `guilhermeserraglio03@gmail.com` e mantenha `guilhermeserraglio@gmail.com` como acesso auxiliar, se desejar).
-
-
-2. Ajuste `ADMIN_EMAILS` conforme os administradores da loja (para este deploy inclua `guilhermeserraglio03@gmail.com`).
-=======
- 
-2. Ajuste `ADMIN_EMAILS` conforme os administradores da loja (para este deploy inclua `guilhermeserraglio03@gmail.com`).
-======= Ajuste `ADMIN_EMAILS` conforme os administradores da loja.
+2. Ajuste `ADMIN_EMAILS` conforme os administradores da loja (para este deploy inclua `guilhermeserraglio03@gmail.com` e mantenha `guilhermeserraglio@gmail.com` como acesso auxiliar, se desejar). Você pode informar os e-mails separados por vírgula (`email1@example.com,email2@example.com`) **ou** enviar um array JSON (`["email1@example.com","email2@example.com"]`).
 
 
 3. Firestore: coleção `products`. Regras iniciais iguais ao pacote anterior.

--- a/duo-parfum-pro/api/products.js
+++ b/duo-parfum-pro/api/products.js
@@ -1,10 +1,42 @@
 const admin = require("firebase-admin");
 
-const ADMIN_EMAILS = (process.env.ADMIN_EMAILS ||
-  "guilhermeserraglio03@gmail.com,guilhermeserraglio@gmail.com")
-  .split(",")
-  .map((email) => email.trim().toLowerCase())
-  .filter(Boolean);
+function parseAdminEmails(source) {
+  const fallback = [
+    "guilhermeserraglio03@gmail.com",
+    "guilhermeserraglio@gmail.com",
+  ];
+
+  if (!source || !source.trim()) {
+    return fallback;
+  }
+
+  const normalizedSource = source.trim();
+  let entries = [];
+
+  if (normalizedSource.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(normalizedSource);
+      if (Array.isArray(parsed)) {
+        entries = parsed;
+      }
+    } catch (err) {
+      console.warn("ADMIN_EMAILS não está em JSON válido:", err);
+    }
+  }
+
+  if (!entries.length) {
+    entries = normalizedSource.split(/[;,\n]/);
+  }
+
+  const emails = entries
+    .map((email) => (typeof email === "string" ? email : ""))
+    .map((email) => email.trim().toLowerCase())
+    .filter(Boolean);
+
+  return emails.length ? emails : fallback;
+}
+
+const ADMIN_EMAILS = parseAdminEmails(process.env.ADMIN_EMAILS);
 
 function normalizePrivateKey(key) {
   if (!key) return undefined;


### PR DESCRIPTION
## Summary
- allow the products API to read administrator email lists from JSON arrays or comma-separated strings
- document the supported ADMIN_EMAILS formats in the deployment README

## Testing
- node - <<'NODE'
const handler = require('./api/products.js');
NODE

------
https://chatgpt.com/codex/tasks/task_e_68d56a2cd72083308bba48cbfc1c229d