### PR TITLE
Restrict checkout to authenticated users

### DIFF
--- a/duo-parfum-pro/app.js
+++ b/duo-parfum-pro/app.js
@@ -45,6 +45,16 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (els.btnLogout) toggle(els.btnLogout, !logged);
     if (els.linkAdmin) toggle(els.linkAdmin, !(logged && ADMIN_EMAILS.includes(user?.email)));
     if (els.linkOrders) toggle(els.linkOrders, !logged);
+    if (els.btnCheckout) {
+      if (!logged) {
+        els.btnCheckout.setAttribute("title", "Faça login para finalizar a compra");
+      } else {
+        els.btnCheckout.removeAttribute("title");
+      }
+    }
+    if (logged && els.ckEmail && typeof user?.email === "string") {
+      els.ckEmail.value = user.email;
+    }
 
     if (!logged) {
       cleanupOrderListeners();
@@ -88,6 +98,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   if (els.btnCheckout) {
     els.btnCheckout.onclick = ()=>{
       if(!state.cart.length){ alert("Seu carrinho está vazio."); return; }
+      if(!auth.currentUser){ alert("Faça login para finalizar a compra."); return; }
       resetCheckoutModal();
       openDrawer(false);
       els.checkoutModal?.showModal();
@@ -323,6 +334,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   async function confirmCheckout(){
     if(state.processingCheckout) return;
+    if(!auth.currentUser){ alert("Faça login para finalizar a compra."); return; }
     const name=(els.ckName?.value||"").trim();
     const email=(els.ckEmail?.value||"").trim().toLowerCase();
     const cep=(els.ckCep?.value||"").trim();


### PR DESCRIPTION
## Summary
- prevent checkout modal from opening unless a user is authenticated
- block checkout confirmation if the session expires or the user signs out
- hint to log in by updating the checkout button title and prefilling the user email

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d869f299e88330963d648d115ad66f