### PR TITLE
Add automatic Mercado Pago payment status tracking

### DIFF
--- a/duo-parfum-pro/README.md
+++ b/duo-parfum-pro/README.md
@@ -23,7 +23,7 @@
    - `FIREBASE_SERVICE_ACCOUNT`: JSON completo do serviço (cole o conteúdo do arquivo gerado pelo Firebase).
    - `FIREBASE_SERVICE_ACCOUNT_BASE64`: mesmo JSON acima, porém convertido para Base64.
    - `FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL` e `FIREBASE_PRIVATE_KEY` separados (no caso da chave privada, substitua as quebras de linha por `\n`).
-5. Configure as variáveis `MP_ACCESS_TOKEN`, `MP_PAYER_EMAIL` (opcional) e `MP_NOTIFICATION_URL` (opcional) na Vercel para gerar pagamentos.
+5. Configure as variáveis `MP_ACCESS_TOKEN`, `MP_PAYER_EMAIL` (opcional) e `MP_NOTIFICATION_URL` (opcional) na Vercel para gerar pagamentos. Defina `MP_NOTIFICATION_URL` apontando para `https://SEU-DOMINIO/api/payment-status` para que o status seja atualizado automaticamente quando o Mercado Pago enviar a notificação.
 6. Deploy na Vercel (arraste esta pasta).
 
 Gerado em 2025-08-10

--- a/duo-parfum-pro/api/_firebase-admin.js
+++ b/duo-parfum-pro/api/_firebase-admin.js
@@ -1,0 +1,78 @@
+const admin = require("firebase-admin");
+
+function normalizePrivateKey(key) {
+  if (!key) return undefined;
+  return key.replace(/\r/g, "").replace(/\\n/g, "\n");
+}
+
+function loadServiceAccountFromEnv() {
+  const rawJson = process.env.FIREBASE_SERVICE_ACCOUNT || "";
+  if (rawJson) {
+    try {
+      const parsed = JSON.parse(rawJson);
+      if (parsed.private_key && parsed.client_email && parsed.project_id) {
+        return {
+          projectId: parsed.project_id,
+          clientEmail: parsed.client_email,
+          privateKey: normalizePrivateKey(parsed.private_key),
+        };
+      }
+    } catch (err) {
+      console.error("⚠️ FIREBASE_SERVICE_ACCOUNT inválido:", err);
+    }
+  }
+
+  const base64Json =
+    process.env.FIREBASE_SERVICE_ACCOUNT_BASE64 ||
+    process.env.FIREBASE_SERVICE_ACCOUNT_JSON_BASE64 ||
+    "";
+  if (base64Json) {
+    try {
+      const decoded = Buffer.from(base64Json, "base64").toString("utf8");
+      const parsed = JSON.parse(decoded);
+      if (parsed.private_key && parsed.client_email && parsed.project_id) {
+        return {
+          projectId: parsed.project_id,
+          clientEmail: parsed.client_email,
+          privateKey: normalizePrivateKey(parsed.private_key),
+        };
+      }
+    } catch (err) {
+      console.error("⚠️ FIREBASE_SERVICE_ACCOUNT_BASE64 inválido:", err);
+    }
+  }
+
+  const projectId = process.env.FIREBASE_PROJECT_ID;
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+  const privateKey = normalizePrivateKey(process.env.FIREBASE_PRIVATE_KEY);
+
+  if (projectId && clientEmail && privateKey) {
+    return { projectId, clientEmail, privateKey };
+  }
+
+  return null;
+}
+
+function getFirebaseAdmin() {
+  if (!admin.apps.length) {
+    const credentials = loadServiceAccountFromEnv();
+
+    if (!credentials) {
+      throw new Error(
+        "⚠️ Credenciais do Firebase Admin não configuradas. Defina FIREBASE_SERVICE_ACCOUNT (JSON), FIREBASE_SERVICE_ACCOUNT_BASE64 ou as variáveis FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL e FIREBASE_PRIVATE_KEY."
+      );
+    }
+
+    admin.initializeApp({
+      credential: admin.credential.cert({
+        projectId: credentials.projectId,
+        clientEmail: credentials.clientEmail,
+        privateKey: credentials.privateKey,
+      }),
+    });
+  }
+
+  return admin;
+}
+
+module.exports = { getFirebaseAdmin };

--- a/duo-parfum-pro/api/payment-status.js
+++ b/duo-parfum-pro/api/payment-status.js
@@ -1,0 +1,241 @@
+const MP_API_BASE = "https://api.mercadopago.com";
+
+const { getFirebaseAdmin } = require("./_firebase-admin");
+
+function parseBody(body) {
+  if (!body) return {};
+  if (typeof body === "string") {
+    try {
+      return JSON.parse(body);
+    } catch (err) {
+      console.error("⚠️ Falha ao interpretar payload de notificação:", err);
+      return {};
+    }
+  }
+  return body;
+}
+
+function extractPaymentId(req, body) {
+  const query = req.query || {};
+
+  const candidates = [
+    query.id,
+    query["data.id"],
+    query.data_id,
+    body?.data?.id,
+    body?.id,
+  ].filter(Boolean);
+
+  if (candidates.length) {
+    const value = String(candidates[0]).trim();
+    if (value) return value;
+  }
+
+  if (body?.resource && typeof body.resource === "string") {
+    const match = body.resource.match(/(\d+)(?:\?.*)?$/);
+    if (match) return match[1];
+  }
+
+  return null;
+}
+
+async function fetchPayment(paymentId, token) {
+  const url = `${MP_API_BASE}/v1/payments/${encodeURIComponent(paymentId)}`;
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  const text = await response.text();
+  let data = null;
+  if (text) {
+    try {
+      data = JSON.parse(text);
+    } catch (err) {
+      console.error("⚠️ Resposta não JSON do Mercado Pago:", err);
+    }
+  }
+
+  if (!response.ok) {
+    const error = new Error(
+      (data && (data.message || data.error)) || `Mercado Pago HTTP ${response.status}`
+    );
+    error.status = response.status;
+    error.details = data;
+    throw error;
+  }
+
+  return data || {};
+}
+
+function extractOrderId(payment) {
+  return (
+    payment?.external_reference ||
+    payment?.metadata?.orderId ||
+    payment?.metadata?.order_id ||
+    ""
+  ).toString().trim();
+}
+
+function mapPaymentStatus(status) {
+  const normalized = (status || "").toString().toLowerCase();
+  if (normalized === "approved") return "paid";
+  if (normalized === "authorized") return "paid";
+  if (["pending", "in_process", "in_mediation"].includes(normalized)) {
+    return "pending";
+  }
+  if (["rejected", "cancelled", "refunded", "charged_back"].includes(normalized)) {
+    return "canceled";
+  }
+  return "pending";
+}
+
+function shouldUpdateStatus(currentStatus, nextStatus) {
+  const current = (currentStatus || "").toString().toLowerCase();
+  const next = (nextStatus || "").toString().toLowerCase();
+
+  if (!next) return false;
+  if (!current) return true;
+  if (current === next) return true;
+
+  if (next === "pending") {
+    return current === "pending";
+  }
+
+  if (next === "paid") {
+    return current === "pending" || current === "paid";
+  }
+
+  if (next === "canceled") {
+    return current === "pending" || current === "paid";
+  }
+
+  return false;
+}
+
+function toTimestamp(admin, value) {
+  if (!value) return undefined;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return undefined;
+  return admin.firestore.Timestamp.fromDate(date);
+}
+
+function cleanObject(source = {}) {
+  return Object.fromEntries(
+    Object.entries(source).filter(([, value]) => value !== undefined)
+  );
+}
+
+function buildPaymentData(admin, payment) {
+  const amount = Number(payment?.transaction_amount);
+  const installments = Number(payment?.installments);
+
+  return cleanObject({
+    id: payment?.id ? String(payment.id) : undefined,
+    status: payment?.status,
+    statusDetail: payment?.status_detail,
+    method: payment?.payment_method_id,
+    type: payment?.payment_type_id,
+    transactionAmount: Number.isFinite(amount) ? amount : undefined,
+    installments: Number.isFinite(installments) ? installments : undefined,
+    payerEmail: payment?.payer?.email,
+    approvedAt: toTimestamp(admin, payment?.date_approved),
+    createdAt: toTimestamp(admin, payment?.date_created),
+    lastUpdatedAt: toTimestamp(admin, payment?.date_last_updated),
+    notificationReceivedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+}
+
+module.exports = async function handler(req, res) {
+  if (!["GET", "POST"].includes(req.method)) {
+    res.setHeader("Allow", "GET, POST");
+    return res.status(405).json({ error: "Método não permitido" });
+  }
+
+  const token = process.env.MP_ACCESS_TOKEN;
+  if (!token) {
+    console.error("⚠️ MP_ACCESS_TOKEN não configurado");
+    return res.status(500).json({ error: "Configuração de pagamento ausente" });
+  }
+
+  const body = req.method === "POST" ? parseBody(req.body) : {};
+  const paymentId = extractPaymentId(req, body);
+
+  if (!paymentId) {
+    console.warn("⚠️ Notificação de pagamento sem identificador", {
+      query: req.query,
+      body,
+    });
+    return res.status(200).json({ received: true, ignored: true });
+  }
+
+  let payment;
+  try {
+    payment = await fetchPayment(paymentId, token);
+  } catch (err) {
+    console.error("❌ Falha ao consultar pagamento no Mercado Pago:", err);
+    return res.status(200).json({ received: true, error: "payment_fetch_failed" });
+  }
+
+  const orderId = extractOrderId(payment);
+  if (!orderId) {
+    console.warn("⚠️ Pagamento sem referência de pedido", paymentId);
+    return res.status(200).json({ received: true, orderFound: false });
+  }
+
+  let admin;
+  try {
+    admin = getFirebaseAdmin();
+  } catch (err) {
+    console.error("❌ Erro ao inicializar Firebase Admin:", err);
+    return res.status(500).json({ error: "Configuração do servidor indisponível" });
+  }
+
+  const db = admin.firestore();
+  const orderRef = db.collection("orders").doc(orderId);
+  const snapshot = await orderRef.get();
+
+  if (!snapshot.exists) {
+    console.warn("⚠️ Pedido não encontrado para atualizar status de pagamento:", orderId);
+    return res.status(200).json({ received: true, orderFound: false });
+  }
+
+  const currentStatus = (snapshot.data()?.status || "").toString().toLowerCase();
+  const nextStatus = mapPaymentStatus(payment?.status);
+
+  const update = {
+    payment: buildPaymentData(admin, payment),
+  };
+
+  if (shouldUpdateStatus(currentStatus, nextStatus)) {
+    update.status = nextStatus;
+
+    if (nextStatus === "paid") {
+      const approvedAt = toTimestamp(admin, payment?.date_approved);
+      if (approvedAt) {
+        update.paidAt = approvedAt;
+      }
+    }
+
+    if (nextStatus === "canceled") {
+      update.canceledAt = admin.firestore.FieldValue.serverTimestamp();
+    }
+  }
+
+  try {
+    await orderRef.set(update, { merge: true });
+  } catch (err) {
+    console.error("❌ Falha ao atualizar pedido com status de pagamento:", err);
+    return res.status(500).json({ error: "Erro ao atualizar pedido" });
+  }
+
+  console.log("✅ Status de pagamento sincronizado", {
+    orderId,
+    currentStatus,
+    appliedStatus: update.status || currentStatus,
+  });
+
+  return res.status(200).json({ received: true, orderId, status: update.status || currentStatus });
+};

--- a/duo-parfum-pro/api/products.js
+++ b/duo-parfum-pro/api/products.js
@@ -1,83 +1,10 @@
-const admin = require("firebase-admin");
+const { getFirebaseAdmin } = require("./_firebase-admin");
 
 const ADMIN_EMAILS = (process.env.ADMIN_EMAILS ||
   "guilhermeserraglio03@gmail.com,guilhermeserraglio@gmail.com")
   .split(",")
   .map((email) => email.trim().toLowerCase())
   .filter(Boolean);
-
-function normalizePrivateKey(key) {
-  if (!key) return undefined;
-  return key.replace(/\r/g, "").replace(/\\n/g, "\n");
-}
-
-function loadServiceAccountFromEnv() {
-  const rawJson = process.env.FIREBASE_SERVICE_ACCOUNT || "";
-  if (rawJson) {
-    try {
-      const parsed = JSON.parse(rawJson);
-      if (parsed.private_key && parsed.client_email && parsed.project_id) {
-        return {
-          projectId: parsed.project_id,
-          clientEmail: parsed.client_email,
-          privateKey: normalizePrivateKey(parsed.private_key),
-        };
-      }
-    } catch (err) {
-      console.error("⚠️ FIREBASE_SERVICE_ACCOUNT inválido:", err);
-    }
-  }
-
-  const base64Json =
-    process.env.FIREBASE_SERVICE_ACCOUNT_BASE64 ||
-    process.env.FIREBASE_SERVICE_ACCOUNT_JSON_BASE64 ||
-    "";
-  if (base64Json) {
-    try {
-      const decoded = Buffer.from(base64Json, "base64").toString("utf8");
-      const parsed = JSON.parse(decoded);
-      if (parsed.private_key && parsed.client_email && parsed.project_id) {
-        return {
-          projectId: parsed.project_id,
-          clientEmail: parsed.client_email,
-          privateKey: normalizePrivateKey(parsed.private_key),
-        };
-      }
-    } catch (err) {
-      console.error("⚠️ FIREBASE_SERVICE_ACCOUNT_BASE64 inválido:", err);
-    }
-  }
-
-  const projectId = process.env.FIREBASE_PROJECT_ID;
-  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
-  const privateKey = normalizePrivateKey(process.env.FIREBASE_PRIVATE_KEY);
-
-  if (projectId && clientEmail && privateKey) {
-    return { projectId, clientEmail, privateKey };
-  }
-
-  return null;
-}
-
-function initializeFirebaseAdmin() {
-  if (admin.apps.length) return;
-
-  const credentials = loadServiceAccountFromEnv();
-
-  if (!credentials) {
-    throw new Error(
-      "⚠️ Credenciais do Firebase Admin não configuradas. Defina FIREBASE_SERVICE_ACCOUNT (JSON), FIREBASE_SERVICE_ACCOUNT_BASE64 ou as variáveis FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL e FIREBASE_PRIVATE_KEY."
-    );
-  }
-
-  admin.initializeApp({
-    credential: admin.credential.cert({
-      projectId: credentials.projectId,
-      clientEmail: credentials.clientEmail,
-      privateKey: credentials.privateKey,
-    }),
-  });
-}
 
 function parseBody(body) {
   if (!body) return {};
@@ -92,7 +19,7 @@ function parseBody(body) {
   return body;
 }
 
-async function authenticateRequest(req) {
+async function authenticateRequest(req, admin) {
   const authHeader = req.headers?.authorization || "";
   const match = authHeader.match(/^Bearer\s+(.+)$/i);
 
@@ -144,8 +71,9 @@ function sanitizeString(value) {
 }
 
 module.exports = async function handler(req, res) {
+  let admin;
   try {
-    initializeFirebaseAdmin();
+    admin = getFirebaseAdmin();
   } catch (err) {
     console.error("❌ Erro ao inicializar Firebase Admin:", err);
     return res.status(500).json({ error: "Configuração do servidor indisponível" });
@@ -164,7 +92,7 @@ module.exports = async function handler(req, res) {
 
   let user;
   try {
-    user = await authenticateRequest(req);
+    user = await authenticateRequest(req, admin);
     console.log("👤 Requisição autenticada para:", user.email, "Método:", req.method);
   } catch (err) {
     console.error("❌ Erro de autenticação:", err.message);

--- a/duo-parfum-pro/style.css
+++ b/duo-parfum-pro/style.css
@@ -1273,3 +1273,38 @@ hr {
     text-align: center;
   }
 }
+
+.payment-status-banner {
+  border-radius: 12px;
+  padding: 14px 18px;
+  margin-bottom: 16px;
+  background: #f6f1eb;
+  color: #5d4037;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  box-shadow: 0 6px 18px rgba(93, 64, 55, 0.12);
+}
+
+.payment-status-banner strong {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.payment-status-banner.is-pending {
+  background: #fff8e1;
+  color: #8a6d3b;
+}
+
+.payment-status-banner.is-paid {
+  background: #e7f7ef;
+  color: #1b5e20;
+}
+
+.payment-status-banner.is-canceled,
+.payment-status-banner.is-error {
+  background: #fdecea;
+  color: #b71c1c;
+}


### PR DESCRIPTION
## Summary
- add a shared Firebase Admin helper and a Mercado Pago notification endpoint that updates order documents when payments change state
- surface real-time payment status feedback in the checkout modal and adjust styling/messages for canceled payments
- document the notification URL configuration and add styles for the new payment status banner

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d86b32cd248330b3f27bb77e9bab1e