### PR TITLE
Add shipping workflow and auto tracking

### DIFF
--- a/duo-parfum-pro/admin.html
+++ b/duo-parfum-pro/admin.html
@@ -474,17 +474,51 @@ auth.onAuthStateChanged(user => {
             })
             .join("");
 
-          const trackingCode = sanitizeTrackingCode(data.trackingCode || data.shipping?.trackingCode || "");
+          const shipping = typeof data.shipping === "object" && data.shipping ? data.shipping : {};
+          const shippingMethod = (shipping.method || data.customer?.shippingMethod || "").toString().toLowerCase();
+          const shippingCost = Number(shipping.cost);
+          const shippingService = (shipping.service || "Correios").toString().trim();
+          const shippingEstimate = shipping.deliveryEstimate || "";
+          const shippingParts = [];
+          if (shippingMethod === "pickup") {
+            shippingParts.push("Retirada no local");
+            if (shipping.instructions) {
+              shippingParts.push(escapeHtml(shipping.instructions));
+            }
+          } else {
+            const serviceLabel = shippingService && shippingService.toLowerCase() !== "correios"
+              ? `Correios — ${escapeHtml(shippingService)}`
+              : "Correios";
+            shippingParts.push(serviceLabel);
+            if (Number.isFinite(shippingCost) && shippingCost > 0) {
+              shippingParts.push(formatCurrency(shippingCost));
+            }
+            if (shippingEstimate) {
+              shippingParts.push(escapeHtml(shippingEstimate));
+            }
+          }
+          const shippingSummary = shippingParts.join(" • ");
+
+          const trackingCode = sanitizeTrackingCode(data.trackingCode || shipping?.trackingCode || "");
           const contactLine = [data.customer?.email, data.customer?.phone].filter(Boolean).join(" · ");
-          const addressLine = [data.customer?.cep, data.customer?.address, data.customer?.city, data.customer?.state]
-            .filter(Boolean)
-            .join(" · ");
+          const addressLine = shippingMethod === "pickup"
+            ? "Retirada no local"
+            : [shipping?.cep || data.customer?.cep, data.customer?.address, data.customer?.city, data.customer?.state]
+                .filter(Boolean)
+                .join(" · ");
           const createdAt = typeof data.createdAt?.toDate === "function" ? data.createdAt.toDate() : null;
           const createdAtLine = createdAt ? `Realizado em ${createdAt.toLocaleString("pt-BR")}` : "";
           const metaLines = [contactLine, addressLine, createdAtLine]
             .filter(Boolean)
             .map(line => `<p class="order-card__meta-line">${escapeHtml(line)}</p>`)
             .join("");
+
+          const trackingGeneratedAt = typeof shipping?.trackingGeneratedAt?.toDate === "function"
+            ? shipping.trackingGeneratedAt.toDate()
+            : null;
+          const trackingGeneratedNote = trackingGeneratedAt
+            ? `<span class="order-card__meta-line muted">${escapeHtml(shipping?.trackingGeneratedBy === "automatic" ? "Gerado automaticamente" : "Atualizado")} em ${escapeHtml(trackingGeneratedAt.toLocaleString("pt-BR"))}</span>`
+            : "";
 
           const trackingHtml = `
             <div class="order-card__tracking-admin">
@@ -494,6 +528,7 @@ auth.onAuthStateChanged(user => {
                 <button class="btn small ghost" onclick="saveTracking('${doc.id}')">Salvar</button>
                 ${trackingCode ? `<a class="btn small ghost" href="https://rastreamento.correios.com.br/app/index.php?codigo=${trackingCode}" target="_blank" rel="noreferrer">Ver no Correios</a>` : ""}
               </div>
+              ${trackingGeneratedNote}
             </div>`;
 
           const statusButtons = [
@@ -523,6 +558,10 @@ auth.onAuthStateChanged(user => {
                 <div>
                   <span class="order-card__label">Pagamento</span>
                   <span class="order-card__value">${escapeHtml(data.customer?.payment || "Não informado")}</span>
+                </div>
+                <div>
+                  <span class="order-card__label">Entrega</span>
+                  <span class="order-card__value">${shippingSummary || "Em confirmação"}</span>
                 </div>
                 <div>
                   <span class="order-card__label">Total</span>
@@ -567,8 +606,18 @@ auth.onAuthStateChanged(user => {
         input.value = sanitized;
 
         const updatePayload = sanitized
-          ? { trackingCode: sanitized }
-          : { trackingCode: firebase.firestore.FieldValue.delete() };
+          ? {
+              trackingCode: sanitized,
+              "shipping.trackingCode": sanitized,
+              "shipping.trackingGeneratedAt": firebase.firestore.FieldValue.serverTimestamp(),
+              "shipping.trackingGeneratedBy": "manual"
+            }
+          : {
+              trackingCode: firebase.firestore.FieldValue.delete(),
+              "shipping.trackingCode": firebase.firestore.FieldValue.delete(),
+              "shipping.trackingGeneratedAt": firebase.firestore.FieldValue.delete(),
+              "shipping.trackingGeneratedBy": firebase.firestore.FieldValue.delete()
+            };
 
         try {
           await db.collection("orders").doc(id).update(updatePayload);

--- a/duo-parfum-pro/api/shipping.js
+++ b/duo-parfum-pro/api/shipping.js
@@ -1,0 +1,111 @@
+const BASE_COST = 16.9;
+const COST_PER_ITEM = 2.4;
+const COST_PER_WEIGHT_UNIT = 1.8;
+const INSURANCE_RATE = 0.018;
+const MIN_COST = 14;
+
+function parseBody(body) {
+  if (!body) return {};
+  if (typeof body === "string") {
+    try {
+      return JSON.parse(body);
+    } catch (err) {
+      return {};
+    }
+  }
+  return body;
+}
+
+function sanitizeCep(value = "") {
+  return value.toString().replace(/\D/g, "").slice(0, 8);
+}
+
+function parseMl(value) {
+  if (!value) return 0;
+  const match = value.toString().match(/(\d+[\d,.]*)/);
+  if (!match) return 0;
+  const normalized = match[1].replace(/\./g, "").replace(/,/g, ".");
+  const ml = Number(normalized);
+  return Number.isFinite(ml) && ml > 0 ? ml : 0;
+}
+
+function computeWeightFactor(items = []) {
+  return items.reduce((acc, item) => {
+    const qty = Math.max(1, Number(item?.qty) || 1);
+    const ml = parseMl(item?.ml);
+    const baseWeight = ml ? ml / 50 : 1;
+    return acc + baseWeight * qty;
+  }, 0);
+}
+
+function estimateDistanceFactor(cep) {
+  if (!cep || cep.length < 3) return 0;
+  const prefix = Number(cep.slice(0, 3));
+  if (!Number.isFinite(prefix)) return 0;
+  return Math.max(0, prefix / 120);
+}
+
+function buildResponse({ cep, items, subtotal }) {
+  const itemCount = items.reduce((acc, item) => acc + Math.max(1, Number(item?.qty) || 1), 0);
+  const weightFactor = computeWeightFactor(items);
+  const distanceFactor = estimateDistanceFactor(cep);
+  const safeSubtotal = Number.isFinite(subtotal) && subtotal > 0 ? subtotal : 0;
+  const insurance = Math.min(20, safeSubtotal * INSURANCE_RATE);
+
+  const rawCost =
+    BASE_COST +
+    itemCount * COST_PER_ITEM +
+    weightFactor * COST_PER_WEIGHT_UNIT +
+    distanceFactor * 4.2 +
+    insurance;
+
+  const cost = Math.max(MIN_COST, Math.round(rawCost * 100) / 100);
+  const minDays = Math.max(3, Math.round(3 + distanceFactor));
+  const maxDays = minDays + 2;
+  const deliveryEstimate = `${minDays} a ${maxDays} dias úteis`;
+
+  return {
+    method: "correios",
+    service: "PAC",
+    cost,
+    currency: "BRL",
+    deliveryEstimate,
+    deliveryDays: { min: minDays, max: maxDays },
+    calculatedAt: new Date().toISOString(),
+  };
+}
+
+module.exports = async function handler(req, res) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).json({ error: "Método não permitido" });
+  }
+
+  const payload = parseBody(req.body);
+  const cep = sanitizeCep(payload?.cep || payload?.zip || "");
+  if (!cep || cep.length !== 8) {
+    return res.status(400).json({ error: "CEP inválido para cálculo de frete" });
+  }
+
+  const items = Array.isArray(payload?.items) ? payload.items.filter(Boolean) : [];
+  if (!items.length) {
+    return res.status(400).json({ error: "Nenhum item informado para cálculo de frete" });
+  }
+
+  const subtotalValue = Number(payload?.subtotal);
+  const subtotal = Number.isFinite(subtotalValue)
+    ? subtotalValue
+    : items.reduce((sum, item) => {
+        const price = Number(item?.price) || 0;
+        const qty = Math.max(1, Number(item?.qty) || 1);
+        return sum + price * qty;
+      }, 0);
+
+  try {
+    const result = buildResponse({ cep, items, subtotal });
+    return res.status(200).json(result);
+  } catch (err) {
+    console.error("Erro ao calcular frete:", err);
+    return res.status(500).json({ error: "Não foi possível calcular o frete" });
+  }
+};

--- a/duo-parfum-pro/index.html
+++ b/duo-parfum-pro/index.html
@@ -229,13 +229,40 @@
           <div class="row wrap" style="margin-top:8px">
             <input id="ckName" class="input" placeholder="Nome completo" style="flex:1;min-width:220px" autocomplete="name">
             <input id="ckEmail" class="input" type="email" placeholder="E-mail" style="flex:1;min-width:220px" autocomplete="email">
-            <input id="ckCep" class="input" placeholder="CEP" style="width:160px">
+            <input id="ckCep" class="input" placeholder="CEP" style="width:160px" inputmode="numeric" maxlength="9">
             <input id="ckAddress" class="input" placeholder="Endereço completo" style="flex:1;min-width:260px">
             <select id="ckPayment" class="input" style="width:200px">
               <option value="pix">Pix</option>
               <option value="card">Cartão de crédito</option>
             </select>
           </div>
+          <div class="checkout-shipping-block">
+            <p class="checkout-section-title">Entrega</p>
+            <div class="checkout-shipping-options" id="ckShippingOptions">
+              <label class="shipping-option" data-shipping-option="pickup">
+                <input type="radio" name="ckShippingMethod" id="ckShippingPickup" value="pickup">
+                <div class="shipping-option__content">
+                  <strong>Retirar no local</strong>
+                  <span>Combine a retirada conosco após a confirmação do pagamento.</span>
+                </div>
+              </label>
+              <label class="shipping-option" data-shipping-option="correios">
+                <input type="radio" name="ckShippingMethod" id="ckShippingCorreios" value="correios" checked>
+                <div class="shipping-option__content">
+                  <strong>Entrega pelos Correios</strong>
+                  <span>Receba em casa com rastreio completo e seguro.</span>
+                </div>
+              </label>
+            </div>
+            <div id="ckShippingCorreiosArea" class="shipping-calc">
+              <p class="muted text-small">Informe seu CEP e clique em "Calcular frete" para ver o valor e o prazo de entrega.</p>
+              <div class="shipping-calc__actions">
+                <button id="ckCalcShipping" type="button" class="btn ghost">Calcular frete</button>
+              </div>
+              <div id="ckShippingSummary" class="shipping-summary muted"></div>
+            </div>
+          </div>
+          <div id="ckTotals" class="checkout-totals"></div>
           <div id="paymentArea" style="margin-top:14px"></div>
           <div class="row gap" style="margin-top:14px">
             <button id="ckConfirm" class="btn">Gerar pagamento</button>

--- a/duo-parfum-pro/style.css
+++ b/duo-parfum-pro/style.css
@@ -1058,6 +1058,125 @@ button:disabled {
   gap: 12px;
 }
 
+/* ===== Checkout & Shipping ===== */
+.checkout-shipping-block {
+  margin-top: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.checkout-section-title {
+  font-weight: 600;
+  color: var(--brand-darker);
+  font-size: 1.05rem;
+}
+
+.checkout-shipping-options {
+  display: grid;
+  gap: 12px;
+}
+
+.shipping-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(140, 91, 77, 0.28);
+  background: rgba(255, 255, 255, 0.92);
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.shipping-option input[type="radio"] {
+  margin-top: 4px;
+  accent-color: var(--brand-dark);
+}
+
+.shipping-option__content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.shipping-option__content strong {
+  font-size: 0.95rem;
+  color: var(--brand-text);
+}
+
+.shipping-option__content span {
+  font-size: 0.82rem;
+  color: var(--brand-muted);
+}
+
+.shipping-option.is-active {
+  border-color: var(--brand-medium);
+  background: var(--brand-white);
+  box-shadow: var(--shadow-soft);
+}
+
+.shipping-calc {
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px dashed rgba(140, 91, 77, 0.25);
+  background: rgba(252, 247, 243, 0.7);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.shipping-calc__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.shipping-summary {
+  font-size: 0.85rem;
+  color: var(--brand-muted);
+}
+
+.checkout-totals {
+  margin-top: 18px;
+  padding: 16px 18px;
+  border-radius: 18px;
+  background: var(--brand-white);
+  border: 1px solid rgba(140, 91, 77, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.checkout-totals__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.95rem;
+  color: var(--brand-text);
+}
+
+.checkout-totals__divider {
+  height: 1px;
+  background: rgba(140, 91, 77, 0.18);
+  margin: 4px 0;
+}
+
+.checkout-totals__total strong {
+  font-size: 1.1rem;
+  color: var(--brand-darker);
+}
+
+.text-small {
+  font-size: 0.82rem;
+}
+
+.error-text {
+  color: #c65d4f;
+  font-weight: 600;
+}
+
 dialog::backdrop {
   background: rgba(45, 29, 23, 0.35);
 }


### PR DESCRIPTION
## Summary
- add delivery method selection, shipping calculation, and totals preview to the checkout dialog
- create a freight calculation API and propagate shipping data through customer orders, payment creation, and admin management screens
- generate Correios tracking codes automatically once Mercado Pago marks an order as paid

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d87221ff0c83308dcf6b7b9aaf9a73