### PR TITLE
Fix Correios shipping calculation for lightweight parcels

### DIFF
--- a/duo-parfum-pro/package.json
+++ b/duo-parfum-pro/package.json
@@ -8,6 +8,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "firebase-admin": "^12.5.0"
+    "firebase-admin": "^12.5.0",
+    "node-fetch": "^3.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "firebase-admin": "^12.5.0"
+    "firebase-admin": "^12.5.0",
+    "node-fetch": "^3.3.2"
   }
 }


### PR DESCRIPTION
## Summary
- tune package dimensions and weight assumptions to reflect the lightweight 5x5cm product while respecting Correios billing rules
- add a fetch polyfill using node-fetch so the shipping quote endpoint works in runtimes without a native fetch implementation
- include both physical and billable weights in the API response for better traceability of the calculated quote

## Testing
- node -e "require('./duo-parfum-pro/api/shipping.js'); console.log('shipping handler loaded');"


------
https://chatgpt.com/codex/tasks/task_e_68d88b86d8448330a373e30a71431aee