### PR TITLE
Improve Correios shipping resilience with protocol fallbacks

### DIFF
--- a/duo-parfum-pro/package.json
+++ b/duo-parfum-pro/package.json
@@ -8,6 +8,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "firebase-admin": "^12.5.0"
+    "firebase-admin": "^12.5.0",
+    "node-fetch": "^3.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "firebase-admin": "^12.5.0"
+    "firebase-admin": "^12.5.0",
+    "node-fetch": "^3.3.2"
   }
 }


### PR DESCRIPTION
## Summary
- add HTTP/HTTPS and JSON/XML fallbacks plus a realistic User-Agent when requesting Correios freight quotes
- retry Correios calls until a valid service payload is parsed before surfacing errors to the shopper
- expose which Correios protocol/format combination succeeded to aid future debugging of the shipping response

## Testing
- node -e "require('./duo-parfum-pro/api/shipping.js'); console.log('ok');"

------
https://chatgpt.com/codex/tasks/task_e_68d88b86d8448330a373e30a71431aee